### PR TITLE
[2 ~ 4 단계 방탈출 예약 결제 / 배포] 켈리(양성욱) 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/domain/member/dto/SaveMemberRequest.java
+++ b/src/main/java/roomescape/domain/member/dto/SaveMemberRequest.java
@@ -9,7 +9,7 @@ public record SaveMemberRequest(
         String name,
         MemberRole role
 ) {
-    public Member toMember(final String encodedPassword) {
+    public Member toModel(final String encodedPassword) {
         return new Member(
                 MemberRole.USER,
                 encodedPassword,

--- a/src/main/java/roomescape/domain/member/model/Member.java
+++ b/src/main/java/roomescape/domain/member/model/Member.java
@@ -77,6 +77,17 @@ public class Member {
         this.email = email;
     }
 
+    @Override
+    public String toString() {
+        return "Member{" +
+                "email=" + email +
+                ", id=" + id +
+                ", role=" + role +
+                ", name=" + name +
+                ", password=" + password +
+                '}';
+    }
+
     public MemberEmail getEmail() {
         return email;
     }

--- a/src/main/java/roomescape/domain/member/model/MemberEmail.java
+++ b/src/main/java/roomescape/domain/member/model/MemberEmail.java
@@ -35,6 +35,13 @@ public class MemberEmail {
         }
     }
 
+    @Override
+    public String toString() {
+        return "MemberEmail{" +
+                "email='" + email + '\'' +
+                '}';
+    }
+
     public String getValue() {
         return email;
     }

--- a/src/main/java/roomescape/domain/member/model/MemberName.java
+++ b/src/main/java/roomescape/domain/member/model/MemberName.java
@@ -30,6 +30,13 @@ public class MemberName {
         }
     }
 
+    @Override
+    public String toString() {
+        return "MemberName{" +
+                "name='" + name + '\'' +
+                '}';
+    }
+
     public String getValue() {
         return name;
     }

--- a/src/main/java/roomescape/domain/member/model/MemberPassword.java
+++ b/src/main/java/roomescape/domain/member/model/MemberPassword.java
@@ -24,6 +24,13 @@ public class MemberPassword {
         }
     }
 
+    @Override
+    public String toString() {
+        return "MemberPassword{" +
+                "password='" + password + '\'' +
+                '}';
+    }
+
     public String getValue() {
         return password;
     }

--- a/src/main/java/roomescape/domain/member/service/MemberService.java
+++ b/src/main/java/roomescape/domain/member/service/MemberService.java
@@ -33,7 +33,7 @@ public class MemberService {
         validateEmailDuplicate(request.email());
         validatePlainPassword(request.password());
 
-        final Member member = request.toMember(passwordEncoder.encode(request.password()));
+        final Member member = request.toModel(passwordEncoder.encode(request.password()));
         return MemberDto.from(memberRepository.save(member));
     }
 

--- a/src/main/java/roomescape/domain/payment/dto/PaymentConfirmResponse.java
+++ b/src/main/java/roomescape/domain/payment/dto/PaymentConfirmResponse.java
@@ -40,7 +40,7 @@ public class PaymentConfirmResponse {
         return offsetDateTime.toLocalDateTime();
     }
 
-    public PaymentHistory toPaymentHistory(final Reservation reservation) {
+    public PaymentHistory toModel(final Reservation reservation) {
         return new PaymentHistory(
                 orderId,
                 PaymentStatus.valueOf(status),

--- a/src/main/java/roomescape/domain/payment/dto/PaymentConfirmResponse.java
+++ b/src/main/java/roomescape/domain/payment/dto/PaymentConfirmResponse.java
@@ -1,8 +1,8 @@
 package roomescape.domain.payment.dto;
 
-import roomescape.domain.member.model.Member;
 import roomescape.domain.payment.model.PaymentHistory;
 import roomescape.domain.payment.model.PaymentStatus;
+import roomescape.domain.reservation.model.Reservation;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -14,6 +14,7 @@ public class PaymentConfirmResponse {
     private final String orderName;
     private final Long totalAmount;
     private final LocalDateTime approvedAt;
+    private final String paymentKey;
     private final String paymentProvider;
 
     public PaymentConfirmResponse(
@@ -22,6 +23,7 @@ public class PaymentConfirmResponse {
             final String orderName,
             final Long totalAmount,
             final String approvedAt,
+            final String paymentKey,
             final Map<String, String> easyPay
     ) {
         this.orderId = orderId;
@@ -29,6 +31,7 @@ public class PaymentConfirmResponse {
         this.orderName = orderName;
         this.totalAmount = totalAmount;
         this.approvedAt = convertLocalDateTime(approvedAt);
+        this.paymentKey = paymentKey;
         this.paymentProvider = easyPay.get("provider");
     }
 
@@ -37,15 +40,16 @@ public class PaymentConfirmResponse {
         return offsetDateTime.toLocalDateTime();
     }
 
-    public PaymentHistory toPaymentHistory(final Member member) {
+    public PaymentHistory toPaymentHistory(final Reservation reservation) {
         return new PaymentHistory(
                 orderId,
                 PaymentStatus.valueOf(status),
                 orderName,
                 totalAmount,
                 approvedAt,
+                paymentKey,
                 paymentProvider,
-                member
+                reservation
         );
     }
 
@@ -63,6 +67,10 @@ public class PaymentConfirmResponse {
 
     public LocalDateTime getApprovedAt() {
         return approvedAt;
+    }
+
+    public String getPaymentKey() {
+        return paymentKey;
     }
 
     public String getPaymentProvider() {

--- a/src/main/java/roomescape/domain/payment/dto/PaymentConfirmResponse.java
+++ b/src/main/java/roomescape/domain/payment/dto/PaymentConfirmResponse.java
@@ -42,7 +42,6 @@ public class PaymentConfirmResponse {
 
     public PaymentHistory toModel(final Reservation reservation) {
         return new PaymentHistory(
-                orderId,
                 PaymentStatus.valueOf(status),
                 orderName,
                 totalAmount,

--- a/src/main/java/roomescape/domain/payment/dto/SavePaymentCredentialRequest.java
+++ b/src/main/java/roomescape/domain/payment/dto/SavePaymentCredentialRequest.java
@@ -4,7 +4,7 @@ import roomescape.domain.payment.model.PaymentCredential;
 
 public record SavePaymentCredentialRequest(String orderId, Long amount) {
 
-    public PaymentCredential toPaymentCredential() {
+    public PaymentCredential toModel() {
         return new PaymentCredential(orderId, amount);
     }
 }

--- a/src/main/java/roomescape/domain/payment/model/PaymentCredential.java
+++ b/src/main/java/roomescape/domain/payment/model/PaymentCredential.java
@@ -13,7 +13,7 @@ public class PaymentCredential {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(length = 100, nullable = false)
     private String orderId;
 
     @Column(nullable = false)

--- a/src/main/java/roomescape/domain/payment/model/PaymentHistory.java
+++ b/src/main/java/roomescape/domain/payment/model/PaymentHistory.java
@@ -18,9 +18,6 @@ public class PaymentHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 100, nullable = false, unique = true)
-    private String orderId;
-
     @Column(length = 20, nullable = false)
     @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
@@ -47,7 +44,6 @@ public class PaymentHistory {
     }
 
     public PaymentHistory(
-            final String orderId,
             final PaymentStatus paymentStatus,
             final String orderName,
             final Long totalAmount,
@@ -56,7 +52,6 @@ public class PaymentHistory {
             final String paymentProvider,
             final Reservation reservation
     ) {
-        this.orderId = orderId;
         this.paymentStatus = paymentStatus;
         this.orderName = orderName;
         this.totalAmount = totalAmount;
@@ -76,10 +71,6 @@ public class PaymentHistory {
 
     public PaymentStatus getPaymentStatus() {
         return paymentStatus;
-    }
-
-    public String getOrderId() {
-        return orderId;
     }
 
     public String getOrderName() {

--- a/src/main/java/roomescape/domain/payment/model/PaymentHistory.java
+++ b/src/main/java/roomescape/domain/payment/model/PaymentHistory.java
@@ -7,8 +7,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import roomescape.domain.member.model.Member;
+import jakarta.persistence.OneToOne;
+import roomescape.domain.reservation.model.Reservation;
 
 import java.time.LocalDateTime;
 
@@ -18,14 +18,14 @@ public class PaymentHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(length = 100, nullable = false, unique = true)
     private String orderId;
 
-    @Column(nullable = false)
+    @Column(length = 20, nullable = false)
     @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
 
-    @Column(nullable = false)
+    @Column(length = 100, nullable = false)
     private String orderName;
 
     @Column(nullable = false)
@@ -34,11 +34,14 @@ public class PaymentHistory {
     @Column(nullable = false)
     private LocalDateTime approvedAt;
 
-    @Column(nullable = false)
+    @Column(length = 100, nullable = false)
+    private String paymentKey;
+
+    @Column(length = 100, nullable = false)
     private String paymentProvider;
 
-    @ManyToOne
-    private Member member;
+    @OneToOne
+    private Reservation reservation;
 
     protected PaymentHistory() {
     }
@@ -49,16 +52,18 @@ public class PaymentHistory {
             final String orderName,
             final Long totalAmount,
             final LocalDateTime approvedAt,
+            final String paymentKey,
             final String paymentProvider,
-            final Member member
+            final Reservation reservation
     ) {
         this.orderId = orderId;
         this.paymentStatus = paymentStatus;
         this.orderName = orderName;
         this.totalAmount = totalAmount;
         this.approvedAt = approvedAt;
+        this.paymentKey = paymentKey;
         this.paymentProvider = paymentProvider;
-        this.member = member;
+        this.reservation = reservation;
     }
 
     public Long getId() {
@@ -85,11 +90,15 @@ public class PaymentHistory {
         return approvedAt;
     }
 
+    public String getPaymentKey() {
+        return paymentKey;
+    }
+
     public String getPaymentProvider() {
         return paymentProvider;
     }
 
-    public Member getMember() {
-        return member;
+    public Reservation getReservation() {
+        return reservation;
     }
 }

--- a/src/main/java/roomescape/domain/payment/model/PaymentHistory.java
+++ b/src/main/java/roomescape/domain/payment/model/PaymentHistory.java
@@ -66,6 +66,10 @@ public class PaymentHistory {
         this.reservation = reservation;
     }
 
+    public void cancelPayment() {
+        this.paymentStatus = PaymentStatus.CANCELED;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/domain/payment/repository/PaymentHistoryRepository.java
+++ b/src/main/java/roomescape/domain/payment/repository/PaymentHistoryRepository.java
@@ -2,6 +2,11 @@ package roomescape.domain.payment.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import roomescape.domain.payment.model.PaymentHistory;
+import roomescape.domain.reservation.model.Reservation;
+
+import java.util.Optional;
 
 public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, Long> {
+
+    Optional<PaymentHistory> findByReservation(Reservation reservation);
 }

--- a/src/main/java/roomescape/domain/payment/service/PaymentService.java
+++ b/src/main/java/roomescape/domain/payment/service/PaymentService.java
@@ -12,6 +12,8 @@ import roomescape.domain.payment.repository.PaymentCredentialRepository;
 import roomescape.domain.payment.repository.PaymentHistoryRepository;
 import roomescape.domain.reservation.model.Reservation;
 
+import java.util.NoSuchElementException;
+
 @Service
 public class PaymentService {
 
@@ -56,5 +58,12 @@ public class PaymentService {
         if (!isMatch) {
             throw new PaymentCredentialMissMatchException("결제 정보가 유효하지 않습니다.");
         }
+    }
+
+    @Transactional
+    public void cancelPayment(final Reservation reservation) {
+        final PaymentHistory paymentHistory = paymentHistoryRepository.findByReservation(reservation)
+                .orElseThrow(() -> new NoSuchElementException("해당 예약에 대한 결제 정보가 없습니다."));
+        paymentHistory.cancelPayment();
     }
 }

--- a/src/main/java/roomescape/domain/payment/service/PaymentService.java
+++ b/src/main/java/roomescape/domain/payment/service/PaymentService.java
@@ -63,9 +63,14 @@ public class PaymentService {
 
     @Transactional
     public void cancelPayment(final Reservation reservation) {
+        final PaymentHistory paymentHistory = getPaymentHistory(reservation);
+        paymentHistory.cancelPayment();
+    }
+
+    private PaymentHistory getPaymentHistory(final Reservation reservation) {
         final PaymentHistory paymentHistory = paymentHistoryRepository.findByReservation(reservation)
                 .orElseThrow(() -> new NoSuchElementException("해당 예약에 대한 결제 정보가 없습니다."));
-        paymentHistory.cancelPayment();
+        return paymentHistory;
     }
 
     public void savePaymentHistory(final SavePaymentHistoryRequest request) {

--- a/src/main/java/roomescape/domain/payment/service/PaymentService.java
+++ b/src/main/java/roomescape/domain/payment/service/PaymentService.java
@@ -69,7 +69,7 @@ public class PaymentService {
 
     private PaymentHistory getPaymentHistory(final Reservation reservation) {
         final PaymentHistory paymentHistory = paymentHistoryRepository.findByReservation(reservation)
-                .orElseThrow(() -> new NoSuchElementException("해당 예약에 대한 결제 정보가 없습니다."));
+                .orElseThrow(() -> new NoSuchElementException("해당 예약에 대한 결제 정보가 없습니다. " + reservation));
         return paymentHistory;
     }
 

--- a/src/main/java/roomescape/domain/payment/service/PaymentService.java
+++ b/src/main/java/roomescape/domain/payment/service/PaymentService.java
@@ -33,7 +33,7 @@ public class PaymentService {
     }
 
     public void saveCredential(final SavePaymentCredentialRequest request) {
-        final PaymentCredential paymentCredential = request.toPaymentCredential();
+        final PaymentCredential paymentCredential = request.toModel();
         paymentCredentialRepository.save(paymentCredential);
     }
 
@@ -47,7 +47,7 @@ public class PaymentService {
         matchPaymentCredential(orderId, amount);
 
         final PaymentConfirmResponse confirmResponse = tossPaymentGateway.confirm(orderId, amount, paymentKey);
-        final PaymentHistory paymentHistory = confirmResponse.toPaymentHistory(reservation);
+        final PaymentHistory paymentHistory = confirmResponse.toModel(reservation);
 
         paymentHistoryRepository.save(paymentHistory);
 
@@ -74,6 +74,6 @@ public class PaymentService {
     }
 
     public void savePaymentHistory(final SavePaymentHistoryRequest request) {
-        paymentHistoryRepository.save(request.toPaymentHistory());
+        paymentHistoryRepository.save(request.toModel());
     }
 }

--- a/src/main/java/roomescape/domain/payment/service/PaymentService.java
+++ b/src/main/java/roomescape/domain/payment/service/PaymentService.java
@@ -10,6 +10,7 @@ import roomescape.domain.payment.model.PaymentHistory;
 import roomescape.domain.payment.pg.PaymentGateway;
 import roomescape.domain.payment.repository.PaymentCredentialRepository;
 import roomescape.domain.payment.repository.PaymentHistoryRepository;
+import roomescape.domain.reservation.dto.SavePaymentHistoryRequest;
 import roomescape.domain.reservation.model.Reservation;
 
 import java.util.NoSuchElementException;
@@ -65,5 +66,9 @@ public class PaymentService {
         final PaymentHistory paymentHistory = paymentHistoryRepository.findByReservation(reservation)
                 .orElseThrow(() -> new NoSuchElementException("해당 예약에 대한 결제 정보가 없습니다."));
         paymentHistory.cancelPayment();
+    }
+
+    public void savePaymentHistory(final SavePaymentHistoryRequest request) {
+        paymentHistoryRepository.save(request.toPaymentHistory());
     }
 }

--- a/src/main/java/roomescape/domain/payment/service/PaymentService.java
+++ b/src/main/java/roomescape/domain/payment/service/PaymentService.java
@@ -2,15 +2,15 @@ package roomescape.domain.payment.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import roomescape.domain.payment.exception.PaymentCredentialMissMatchException;
-import roomescape.domain.member.model.Member;
 import roomescape.domain.payment.dto.PaymentConfirmResponse;
 import roomescape.domain.payment.dto.SavePaymentCredentialRequest;
+import roomescape.domain.payment.exception.PaymentCredentialMissMatchException;
 import roomescape.domain.payment.model.PaymentCredential;
 import roomescape.domain.payment.model.PaymentHistory;
 import roomescape.domain.payment.pg.PaymentGateway;
 import roomescape.domain.payment.repository.PaymentCredentialRepository;
 import roomescape.domain.payment.repository.PaymentHistoryRepository;
+import roomescape.domain.reservation.model.Reservation;
 
 @Service
 public class PaymentService {
@@ -39,12 +39,12 @@ public class PaymentService {
             final String orderId,
             final Long amount,
             final String paymentKey,
-            final Member member
+            final Reservation reservation
     ) {
         matchPaymentCredential(orderId, amount);
 
         final PaymentConfirmResponse confirmResponse = tossPaymentGateway.confirm(orderId, amount, paymentKey);
-        final PaymentHistory paymentHistory = confirmResponse.toPaymentHistory(member);
+        final PaymentHistory paymentHistory = confirmResponse.toPaymentHistory(reservation);
 
         paymentHistoryRepository.save(paymentHistory);
 

--- a/src/main/java/roomescape/domain/payment/service/PaymentService.java
+++ b/src/main/java/roomescape/domain/payment/service/PaymentService.java
@@ -10,7 +10,7 @@ import roomescape.domain.payment.model.PaymentHistory;
 import roomescape.domain.payment.pg.PaymentGateway;
 import roomescape.domain.payment.repository.PaymentCredentialRepository;
 import roomescape.domain.payment.repository.PaymentHistoryRepository;
-import roomescape.domain.reservation.dto.SavePaymentHistoryRequest;
+import roomescape.domain.reservation.dto.PaymentHistoryDto;
 import roomescape.domain.reservation.model.Reservation;
 
 import java.util.NoSuchElementException;
@@ -73,7 +73,7 @@ public class PaymentService {
         return paymentHistory;
     }
 
-    public void savePaymentHistory(final SavePaymentHistoryRequest request) {
+    public void savePaymentHistory(final PaymentHistoryDto request) {
         paymentHistoryRepository.save(request.toModel());
     }
 }

--- a/src/main/java/roomescape/domain/reservation/controller/AdminReservationController.java
+++ b/src/main/java/roomescape/domain/reservation/controller/AdminReservationController.java
@@ -12,7 +12,7 @@ import roomescape.domain.reservation.dto.ReservationDto;
 import roomescape.domain.reservation.dto.ReservationResponse;
 import roomescape.domain.reservation.dto.ReservationTimeDto;
 import roomescape.domain.reservation.dto.ReservationTimeResponse;
-import roomescape.domain.reservation.dto.SaveReservationRequest;
+import roomescape.domain.reservation.dto.SaveAdminReservationRequest;
 import roomescape.domain.reservation.dto.SaveReservationTimeRequest;
 import roomescape.domain.reservation.dto.SaveThemeRequest;
 import roomescape.domain.reservation.dto.SearchReservationsRequest;
@@ -59,7 +59,7 @@ public class AdminReservationController {
     }
 
     @PostMapping("/admin/reservations")
-    public ResponseEntity<ReservationResponse> saveReservation(@RequestBody final SaveReservationRequest request) {
+    public ResponseEntity<ReservationResponse> saveReservation(@RequestBody final SaveAdminReservationRequest request) {
         final ReservationDto savedReservation = reservationService.saveReservation(request);
         return ResponseEntity.created(URI.create("/reservations/" + savedReservation.id()))
                 .body(ReservationResponse.from(savedReservation));

--- a/src/main/java/roomescape/domain/reservation/controller/AdminReservationController.java
+++ b/src/main/java/roomescape/domain/reservation/controller/AdminReservationController.java
@@ -71,6 +71,14 @@ public class AdminReservationController {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/admin/times")
+    public List<ReservationTimeResponse> getReservationTimes() {
+        return reservationTimeService.getReservationTimes()
+                .stream()
+                .map(ReservationTimeResponse::from)
+                .toList();
+    }
+
     @PostMapping("/admin/times")
     public ResponseEntity<ReservationTimeResponse> saveReservationTime(@RequestBody final SaveReservationTimeRequest request) {
         final ReservationTimeDto savedReservationTime = reservationTimeService.saveReservationTime(request);

--- a/src/main/java/roomescape/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/roomescape/domain/reservation/controller/ReservationController.java
@@ -27,7 +27,7 @@ public class ReservationController {
 
     @GetMapping("/reservations-mine")
     public List<MyReservationResponse> getMyReservations(@Authenticated final AuthenticatedMember authenticatedMember) {
-        return reservationService.getMyReservations(authenticatedMember.id())
+        return reservationService.getMyReservationsWithPaymentHistory(authenticatedMember.id())
                 .stream()
                 .map(MyReservationResponse::from)
                 .toList();

--- a/src/main/java/roomescape/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/roomescape/domain/reservation/controller/ReservationController.java
@@ -38,7 +38,7 @@ public class ReservationController {
             @RequestBody final SaveReservationRequest request,
             @Authenticated final AuthenticatedMember authenticatedMember
     ) {
-        final ReservationDto savedReservation = reservationService.saveReservation(
+        final ReservationDto savedReservation = reservationService.saveReservationWithPaymentConfirm(
                 request.setMemberId(authenticatedMember.id()));
         final ReservationResponse response = ReservationResponse.from(savedReservation);
 

--- a/src/main/java/roomescape/domain/reservation/controller/ReservationTimeController.java
+++ b/src/main/java/roomescape/domain/reservation/controller/ReservationTimeController.java
@@ -4,7 +4,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import roomescape.domain.reservation.dto.AvailableReservationTimeResponse;
-import roomescape.domain.reservation.dto.ReservationTimeResponse;
 import roomescape.domain.reservation.service.ReservationTimeService;
 
 import java.time.LocalDate;
@@ -17,14 +16,6 @@ public class ReservationTimeController {
 
     public ReservationTimeController(final ReservationTimeService reservationTimeService) {
         this.reservationTimeService = reservationTimeService;
-    }
-
-    @GetMapping("/times")
-    public List<ReservationTimeResponse> getReservationTimes() {
-        return reservationTimeService.getReservationTimes()
-                .stream()
-                .map(ReservationTimeResponse::from)
-                .toList();
     }
 
     @GetMapping("/available-reservation-times")

--- a/src/main/java/roomescape/domain/reservation/controller/ReservationWaitingController.java
+++ b/src/main/java/roomescape/domain/reservation/controller/ReservationWaitingController.java
@@ -8,6 +8,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import roomescape.auth.principal.AuthenticatedMember;
+import roomescape.domain.reservation.dto.ApproveReservationWaitingRequest;
+import roomescape.domain.reservation.dto.ReservationDto;
+import roomescape.domain.reservation.dto.ReservationResponse;
 import roomescape.domain.reservation.service.ReservationWaitingService;
 import roomescape.domain.reservation.dto.MyReservationWaitingResponse;
 import roomescape.domain.reservation.dto.ReservationWaitingResponse;
@@ -54,6 +57,15 @@ public class ReservationWaitingController {
 
         return ResponseEntity.created(URI.create("/reservations/" + reservationWaitingId))
                 .body(saveReservationWaitingResponse);
+    }
+
+    @PostMapping("/reservation-waiting/approve")
+    public ResponseEntity<ReservationResponse> approveReservationWaiting(@RequestBody final ApproveReservationWaitingRequest request) {
+        final ReservationDto savedReservation = reservationWaitingService.approveReservationWaiting(request);
+        final ReservationResponse response = ReservationResponse.from(savedReservation);
+
+        return ResponseEntity.created(URI.create("/reservations/" + savedReservation.id()))
+                .body(response);
     }
 
     @DeleteMapping("/reservation-waiting/{reservationWaitingId}")

--- a/src/main/java/roomescape/domain/reservation/dto/ApproveReservationWaitingRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/ApproveReservationWaitingRequest.java
@@ -1,0 +1,9 @@
+package roomescape.domain.reservation.dto;
+
+public record ApproveReservationWaitingRequest(
+        Long reservationWaitingId,
+        String orderId,
+        Long amount,
+        String paymentKey
+) {
+}

--- a/src/main/java/roomescape/domain/reservation/dto/MyReservationResponse.java
+++ b/src/main/java/roomescape/domain/reservation/dto/MyReservationResponse.java
@@ -8,15 +8,19 @@ public record MyReservationResponse(
         String theme,
         LocalDate date,
         LocalTime time,
-        String status
+        String status,
+        String paymentKey,
+        Long amount
 ) {
-    public static MyReservationResponse from(final ReservationDto reservation) {
+    public static MyReservationResponse from(final ReservationWithPaymentHistoryDto reservationWithPaymentHistoryDto) {
         return new MyReservationResponse(
-                reservation.id(),
-                reservation.theme().name().getValue(),
-                reservation.date().getValue(),
-                reservation.time().startAt(),
-                reservation.status().getDescription()
+                reservationWithPaymentHistoryDto.id(),
+                reservationWithPaymentHistoryDto.theme().name().getValue(),
+                reservationWithPaymentHistoryDto.date().getValue(),
+                reservationWithPaymentHistoryDto.time().startAt(),
+                reservationWithPaymentHistoryDto.status().getDescription(),
+                reservationWithPaymentHistoryDto.paymentKey(),
+                reservationWithPaymentHistoryDto.totalAmount()
         );
     }
 }

--- a/src/main/java/roomescape/domain/reservation/dto/MyReservationWaitingResponse.java
+++ b/src/main/java/roomescape/domain/reservation/dto/MyReservationWaitingResponse.java
@@ -8,7 +8,8 @@ public record MyReservationWaitingResponse(
         String theme,
         LocalDate date,
         LocalTime time,
-        int order
+        int order,
+        boolean paymentAvailable
 ) {
     public static MyReservationWaitingResponse from(final ReservationWaitingWithOrderDto reservationWaiting) {
         return new MyReservationWaitingResponse(
@@ -16,7 +17,8 @@ public record MyReservationWaitingResponse(
                 reservationWaiting.theme().name().getValue(),
                 reservationWaiting.date().getValue(),
                 reservationWaiting.time().startAt(),
-                reservationWaiting.order()
+                reservationWaiting.order(),
+                reservationWaiting.paymentAvailable()
         );
     }
 }

--- a/src/main/java/roomescape/domain/reservation/dto/PaymentHistoryDto.java
+++ b/src/main/java/roomescape/domain/reservation/dto/PaymentHistoryDto.java
@@ -7,7 +7,6 @@ import roomescape.domain.reservation.model.Reservation;
 import java.time.LocalDateTime;
 
 public record PaymentHistoryDto(
-        String orderId,
         PaymentStatus paymentStatus,
         String orderName,
         Long totalAmount,
@@ -18,7 +17,6 @@ public record PaymentHistoryDto(
 ) {
     public PaymentHistory toModel() {
         return new PaymentHistory(
-                orderId,
                 paymentStatus,
                 orderName,
                 totalAmount,

--- a/src/main/java/roomescape/domain/reservation/dto/PaymentHistoryDto.java
+++ b/src/main/java/roomescape/domain/reservation/dto/PaymentHistoryDto.java
@@ -6,7 +6,7 @@ import roomescape.domain.reservation.model.Reservation;
 
 import java.time.LocalDateTime;
 
-public record SavePaymentHistoryRequest(
+public record PaymentHistoryDto(
         String orderId,
         PaymentStatus paymentStatus,
         String orderName,

--- a/src/main/java/roomescape/domain/reservation/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/domain/reservation/dto/ReservationResponse.java
@@ -9,7 +9,8 @@ public record ReservationResponse(
         MemberResponse member,
         LocalDate date,
         ReservationTimeResponse time,
-        ThemeResponse theme
+        ThemeResponse theme,
+        String status
 ) {
     public static ReservationResponse from(final ReservationDto reservation) {
         return new ReservationResponse(
@@ -21,7 +22,8 @@ public record ReservationResponse(
                 ),
                 reservation.date().getValue(),
                 ReservationTimeResponse.from(reservation.time()),
-                ThemeResponse.from(reservation.theme())
+                ThemeResponse.from(reservation.theme()),
+                reservation.status().getDescription()
         );
     }
 }

--- a/src/main/java/roomescape/domain/reservation/dto/ReservationWaitingWithOrderDto.java
+++ b/src/main/java/roomescape/domain/reservation/dto/ReservationWaitingWithOrderDto.java
@@ -15,13 +15,13 @@ public record ReservationWaitingWithOrderDto(
 ) {
     public static ReservationWaitingWithOrderDto of(final ReservationWaitingWithOrder reservationWaitingWithOrder, final boolean paymentAvailable) {
         return new ReservationWaitingWithOrderDto(
-                reservationWaitingWithOrder.getReservationWaiting().getId(),
-                reservationWaitingWithOrder.getOrder(),
+                reservationWaitingWithOrder.reservationWaiting().getId(),
+                reservationWaitingWithOrder.order(),
                 paymentAvailable,
-                reservationWaitingWithOrder.getReservationWaiting().getDate(),
-                ReservationTimeDto.from(reservationWaitingWithOrder.getReservationWaiting().getTime()),
-                ThemeDto.from(reservationWaitingWithOrder.getReservationWaiting().getTheme()),
-                MemberDto.from(reservationWaitingWithOrder.getReservationWaiting().getMember())
+                reservationWaitingWithOrder.reservationWaiting().getDate(),
+                ReservationTimeDto.from(reservationWaitingWithOrder.reservationWaiting().getTime()),
+                ThemeDto.from(reservationWaitingWithOrder.reservationWaiting().getTheme()),
+                MemberDto.from(reservationWaitingWithOrder.reservationWaiting().getMember())
         );
     }
 }

--- a/src/main/java/roomescape/domain/reservation/dto/ReservationWaitingWithOrderDto.java
+++ b/src/main/java/roomescape/domain/reservation/dto/ReservationWaitingWithOrderDto.java
@@ -13,7 +13,7 @@ public record ReservationWaitingWithOrderDto(
         ThemeDto theme,
         MemberDto member
 ) {
-    public static ReservationWaitingWithOrderDto from(final ReservationWaitingWithOrder reservationWaitingWithOrder, final boolean paymentAvailable) {
+    public static ReservationWaitingWithOrderDto of(final ReservationWaitingWithOrder reservationWaitingWithOrder, final boolean paymentAvailable) {
         return new ReservationWaitingWithOrderDto(
                 reservationWaitingWithOrder.getReservationWaiting().getId(),
                 reservationWaitingWithOrder.getOrder(),

--- a/src/main/java/roomescape/domain/reservation/dto/ReservationWaitingWithOrderDto.java
+++ b/src/main/java/roomescape/domain/reservation/dto/ReservationWaitingWithOrderDto.java
@@ -7,15 +7,17 @@ import roomescape.domain.reservation.model.ReservationWaitingWithOrder;
 public record ReservationWaitingWithOrderDto(
         Long id,
         int order,
+        boolean paymentAvailable,
         ReservationDate date,
         ReservationTimeDto time,
         ThemeDto theme,
         MemberDto member
 ) {
-    public static ReservationWaitingWithOrderDto from(ReservationWaitingWithOrder reservationWaitingWithOrder) {
+    public static ReservationWaitingWithOrderDto from(final ReservationWaitingWithOrder reservationWaitingWithOrder, final boolean paymentAvailable) {
         return new ReservationWaitingWithOrderDto(
                 reservationWaitingWithOrder.getReservationWaiting().getId(),
                 reservationWaitingWithOrder.getOrder(),
+                paymentAvailable,
                 reservationWaitingWithOrder.getReservationWaiting().getDate(),
                 ReservationTimeDto.from(reservationWaitingWithOrder.getReservationWaiting().getTime()),
                 ThemeDto.from(reservationWaitingWithOrder.getReservationWaiting().getTheme()),

--- a/src/main/java/roomescape/domain/reservation/dto/ReservationWithPaymentHistoryDto.java
+++ b/src/main/java/roomescape/domain/reservation/dto/ReservationWithPaymentHistoryDto.java
@@ -1,0 +1,35 @@
+package roomescape.domain.reservation.dto;
+
+import roomescape.domain.member.dto.MemberDto;
+import roomescape.domain.reservation.model.Reservation;
+import roomescape.domain.reservation.model.ReservationDate;
+import roomescape.domain.reservation.model.ReservationStatus;
+
+public record ReservationWithPaymentHistoryDto(
+        Long id,
+        ReservationStatus status,
+        ReservationDate date,
+        ReservationTimeDto time,
+        ThemeDto theme,
+        MemberDto member,
+        String paymentKey,
+        Long totalAmount
+) {
+    public static ReservationWithPaymentHistoryDto from(
+            final Reservation reservation,
+            final String paymentKey,
+            final Long totalAmount
+
+    ) {
+        return new ReservationWithPaymentHistoryDto(
+                reservation.getId(),
+                reservation.getStatus(),
+                reservation.getDate(),
+                ReservationTimeDto.from(reservation.getTime()),
+                ThemeDto.from(reservation.getTheme()),
+                MemberDto.from(reservation.getMember()),
+                paymentKey,
+                totalAmount
+        );
+    }
+}

--- a/src/main/java/roomescape/domain/reservation/dto/ReservationWithPaymentHistoryDto.java
+++ b/src/main/java/roomescape/domain/reservation/dto/ReservationWithPaymentHistoryDto.java
@@ -15,7 +15,7 @@ public record ReservationWithPaymentHistoryDto(
         String paymentKey,
         Long totalAmount
 ) {
-    public static ReservationWithPaymentHistoryDto from(
+    public static ReservationWithPaymentHistoryDto of(
             final Reservation reservation,
             final String paymentKey,
             final Long totalAmount

--- a/src/main/java/roomescape/domain/reservation/dto/SaveAdminReservationRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/SaveAdminReservationRequest.java
@@ -31,7 +31,7 @@ public record SaveAdminReservationRequest(
         );
     }
 
-    public Reservation toReservation(
+    public Reservation toModel(
             final ReservationTime reservationTime,
             final Theme theme,
             final Member member

--- a/src/main/java/roomescape/domain/reservation/dto/SaveAdminReservationRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/SaveAdminReservationRequest.java
@@ -1,0 +1,47 @@
+package roomescape.domain.reservation.dto;
+
+import roomescape.domain.member.model.Member;
+import roomescape.domain.reservation.model.Reservation;
+import roomescape.domain.reservation.model.ReservationStatus;
+import roomescape.domain.reservation.model.ReservationTime;
+import roomescape.domain.reservation.model.Theme;
+
+import java.time.LocalDate;
+
+public record SaveAdminReservationRequest(
+        LocalDate date,
+        Long memberId,
+        Long timeId,
+        Long themeId,
+        String orderId,
+        String orderName,
+        Long amount,
+        String paymentKey
+) {
+    public SaveAdminReservationRequest setMemberId(final Long memberId) {
+        return new SaveAdminReservationRequest(
+                date,
+                memberId,
+                timeId,
+                themeId,
+                orderId,
+                orderName,
+                amount,
+                paymentKey
+        );
+    }
+
+    public Reservation toReservation(
+            final ReservationTime reservationTime,
+            final Theme theme,
+            final Member member
+    ) {
+        return new Reservation(
+                ReservationStatus.RESERVATION,
+                date,
+                reservationTime,
+                theme,
+                member
+        );
+    }
+}

--- a/src/main/java/roomescape/domain/reservation/dto/SaveAdminReservationRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/SaveAdminReservationRequest.java
@@ -1,11 +1,5 @@
 package roomescape.domain.reservation.dto;
 
-import roomescape.domain.member.model.Member;
-import roomescape.domain.reservation.model.Reservation;
-import roomescape.domain.reservation.model.ReservationStatus;
-import roomescape.domain.reservation.model.ReservationTime;
-import roomescape.domain.reservation.model.Theme;
-
 import java.time.LocalDate;
 
 public record SaveAdminReservationRequest(
@@ -28,20 +22,6 @@ public record SaveAdminReservationRequest(
                 orderName,
                 amount,
                 paymentKey
-        );
-    }
-
-    public Reservation toModel(
-            final ReservationTime reservationTime,
-            final Theme theme,
-            final Member member
-    ) {
-        return new Reservation(
-                ReservationStatus.RESERVATION,
-                date,
-                reservationTime,
-                theme,
-                member
         );
     }
 }

--- a/src/main/java/roomescape/domain/reservation/dto/SavePaymentHistoryRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/SavePaymentHistoryRequest.java
@@ -16,7 +16,7 @@ public record SavePaymentHistoryRequest(
         String paymentProvider,
         Reservation reservation
 ) {
-    public PaymentHistory toPaymentHistory() {
+    public PaymentHistory toModel() {
         return new PaymentHistory(
                 orderId,
                 paymentStatus,

--- a/src/main/java/roomescape/domain/reservation/dto/SavePaymentHistoryRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/SavePaymentHistoryRequest.java
@@ -1,0 +1,31 @@
+package roomescape.domain.reservation.dto;
+
+import roomescape.domain.payment.model.PaymentHistory;
+import roomescape.domain.payment.model.PaymentStatus;
+import roomescape.domain.reservation.model.Reservation;
+
+import java.time.LocalDateTime;
+
+public record SavePaymentHistoryRequest(
+        String orderId,
+        PaymentStatus paymentStatus,
+        String orderName,
+        Long totalAmount,
+        LocalDateTime approvedAt,
+        String paymentKey,
+        String paymentProvider,
+        Reservation reservation
+) {
+    public PaymentHistory toPaymentHistory() {
+        return new PaymentHistory(
+                orderId,
+                paymentStatus,
+                orderName,
+                totalAmount,
+                approvedAt,
+                paymentKey,
+                paymentProvider,
+                reservation
+        );
+    }
+}

--- a/src/main/java/roomescape/domain/reservation/dto/SaveReservationRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/SaveReservationRequest.java
@@ -1,11 +1,5 @@
 package roomescape.domain.reservation.dto;
 
-import roomescape.domain.member.model.Member;
-import roomescape.domain.reservation.model.Reservation;
-import roomescape.domain.reservation.model.ReservationStatus;
-import roomescape.domain.reservation.model.ReservationTime;
-import roomescape.domain.reservation.model.Theme;
-
 import java.time.LocalDate;
 
 public record SaveReservationRequest(
@@ -26,20 +20,6 @@ public record SaveReservationRequest(
                 orderId,
                 amount,
                 paymentKey
-        );
-    }
-
-    public Reservation toModel(
-            final ReservationTime reservationTime,
-            final Theme theme,
-            final Member member
-    ) {
-        return new Reservation(
-                ReservationStatus.RESERVATION,
-                date,
-                reservationTime,
-                theme,
-                member
         );
     }
 }

--- a/src/main/java/roomescape/domain/reservation/dto/SaveReservationRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/SaveReservationRequest.java
@@ -29,7 +29,7 @@ public record SaveReservationRequest(
         );
     }
 
-    public Reservation toReservation(
+    public Reservation toModel(
             final ReservationTime reservationTime,
             final Theme theme,
             final Member member

--- a/src/main/java/roomescape/domain/reservation/dto/SaveReservationTimeRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/SaveReservationTimeRequest.java
@@ -5,7 +5,7 @@ import roomescape.domain.reservation.model.ReservationTime;
 import java.time.LocalTime;
 
 public record SaveReservationTimeRequest(LocalTime startAt) {
-    public ReservationTime toReservationTime() {
+    public ReservationTime toModel() {
         return new ReservationTime(startAt);
     }
 }

--- a/src/main/java/roomescape/domain/reservation/dto/SaveThemeRequest.java
+++ b/src/main/java/roomescape/domain/reservation/dto/SaveThemeRequest.java
@@ -3,7 +3,7 @@ package roomescape.domain.reservation.dto;
 import roomescape.domain.reservation.model.Theme;
 
 public record SaveThemeRequest(String name, String description, String thumbnail) {
-    public Theme toTheme() {
+    public Theme toModel() {
         return new Theme(name, description, thumbnail);
     }
 }

--- a/src/main/java/roomescape/domain/reservation/model/Reservation.java
+++ b/src/main/java/roomescape/domain/reservation/model/Reservation.java
@@ -1,5 +1,6 @@
 package roomescape.domain.reservation.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -30,6 +31,7 @@ public class Reservation {
     private Member member;
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
     private ReservationStatus status;
 
     @Embedded

--- a/src/main/java/roomescape/domain/reservation/model/Reservation.java
+++ b/src/main/java/roomescape/domain/reservation/model/Reservation.java
@@ -103,6 +103,18 @@ public class Reservation {
         }
     }
 
+    @Override
+    public String toString() {
+        return "Reservation{" +
+                "date=" + date +
+                ", id=" + id +
+                ", time=" + time +
+                ", theme=" + theme +
+                ", member=" + member +
+                ", status=" + status +
+                '}';
+    }
+
     public void cancel() {
         this.status = ReservationStatus.CANCEL;
     }

--- a/src/main/java/roomescape/domain/reservation/model/Reservation.java
+++ b/src/main/java/roomescape/domain/reservation/model/Reservation.java
@@ -103,6 +103,14 @@ public class Reservation {
         }
     }
 
+    public void cancel() {
+        this.status = ReservationStatus.CANCEL;
+    }
+
+    public boolean isCancel() {
+        return this.status == ReservationStatus.CANCEL;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/domain/reservation/model/ReservationDate.java
+++ b/src/main/java/roomescape/domain/reservation/model/ReservationDate.java
@@ -26,6 +26,13 @@ public class ReservationDate {
         }
     }
 
+    @Override
+    public String toString() {
+        return "ReservationDate{" +
+                "date=" + date +
+                '}';
+    }
+
     public LocalDate getValue() {
         return date;
     }

--- a/src/main/java/roomescape/domain/reservation/model/ReservationStatus.java
+++ b/src/main/java/roomescape/domain/reservation/model/ReservationStatus.java
@@ -3,6 +3,7 @@ package roomescape.domain.reservation.model;
 public enum ReservationStatus {
     PENDING("대기"),
     RESERVATION("예약"),
+    CANCEL("취소"),
     END("완료");
 
     private final String description;

--- a/src/main/java/roomescape/domain/reservation/model/ReservationTime.java
+++ b/src/main/java/roomescape/domain/reservation/model/ReservationTime.java
@@ -38,6 +38,14 @@ public class ReservationTime {
         }
     }
 
+    @Override
+    public String toString() {
+        return "ReservationTime{" +
+                "id=" + id +
+                ", startAt=" + startAt +
+                '}';
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/domain/reservation/model/ReservationWaiting.java
+++ b/src/main/java/roomescape/domain/reservation/model/ReservationWaiting.java
@@ -69,7 +69,7 @@ public class ReservationWaiting {
     protected ReservationWaiting() {
     }
 
-    public Reservation makeReservation() {
+    public Reservation reserve() {
         return new Reservation(
                 ReservationStatus.RESERVATION,
                 date.getValue(),

--- a/src/main/java/roomescape/domain/reservation/model/ReservationWaitingWithOrder.java
+++ b/src/main/java/roomescape/domain/reservation/model/ReservationWaitingWithOrder.java
@@ -1,20 +1,10 @@
 package roomescape.domain.reservation.model;
 
-public class ReservationWaitingWithOrder {
+public record ReservationWaitingWithOrder(ReservationWaiting reservationWaiting, int order) {
 
-    private final ReservationWaiting reservationWaiting;
-    private final int order;
+    private static final int FIRST_RESERVATION_WAITING_ORDER_VALUE = 1;
 
-    public ReservationWaitingWithOrder(final ReservationWaiting reservationWaiting, final int order) {
-        this.reservationWaiting = reservationWaiting;
-        this.order = order;
-    }
-
-    public int getOrder() {
-        return order;
-    }
-
-    public ReservationWaiting getReservationWaiting() {
-        return reservationWaiting;
+    public boolean isFirstOrder() {
+        return this.order == FIRST_RESERVATION_WAITING_ORDER_VALUE;
     }
 }

--- a/src/main/java/roomescape/domain/reservation/model/Theme.java
+++ b/src/main/java/roomescape/domain/reservation/model/Theme.java
@@ -64,6 +64,16 @@ public class Theme {
         this.thumbnail = thumbnail;
     }
 
+    @Override
+    public String toString() {
+        return "Theme{" +
+                "description=" + description +
+                ", id=" + id +
+                ", name=" + name +
+                ", thumbnail=" + thumbnail +
+                '}';
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/domain/reservation/model/ThemeDescription.java
+++ b/src/main/java/roomescape/domain/reservation/model/ThemeDescription.java
@@ -31,6 +31,13 @@ public class ThemeDescription {
         }
     }
 
+    @Override
+    public String toString() {
+        return "ThemeDescription{" +
+                "description='" + description + '\'' +
+                '}';
+    }
+
     public String getValue() {
         return description;
     }

--- a/src/main/java/roomescape/domain/reservation/model/ThemeName.java
+++ b/src/main/java/roomescape/domain/reservation/model/ThemeName.java
@@ -31,6 +31,13 @@ public class ThemeName {
         }
     }
 
+    @Override
+    public String toString() {
+        return "ThemeName{" +
+                "name='" + name + '\'' +
+                '}';
+    }
+
     public String getValue() {
         return name;
     }

--- a/src/main/java/roomescape/domain/reservation/model/ThemeThumbnail.java
+++ b/src/main/java/roomescape/domain/reservation/model/ThemeThumbnail.java
@@ -31,6 +31,13 @@ public class ThemeThumbnail {
         }
     }
 
+    @Override
+    public String toString() {
+        return "ThemeThumbnail{" +
+                "thumbnail='" + thumbnail + '\'' +
+                '}';
+    }
+
     public String getValue() {
         return thumbnail;
     }

--- a/src/main/java/roomescape/domain/reservation/repository/CustomReservationWaitingRepository.java
+++ b/src/main/java/roomescape/domain/reservation/repository/CustomReservationWaitingRepository.java
@@ -3,7 +3,10 @@ package roomescape.domain.reservation.repository;
 import roomescape.domain.reservation.model.ReservationWaitingWithOrder;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomReservationWaitingRepository {
     List<ReservationWaitingWithOrder> findAllReservationWaitingWithOrdersByMemberId(Long memberId);
+
+    Optional<ReservationWaitingWithOrder> findReservationWaitingWithOrder(Long reservationWaitingId);
 }

--- a/src/main/java/roomescape/domain/reservation/repository/CustomReservationWaitingRepositoryImpl.java
+++ b/src/main/java/roomescape/domain/reservation/repository/CustomReservationWaitingRepositoryImpl.java
@@ -13,7 +13,6 @@ import roomescape.domain.reservation.model.ReservationWaiting;
 import roomescape.domain.reservation.model.ReservationWaitingWithOrder;
 import roomescape.domain.reservation.model.Theme;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -90,89 +89,36 @@ public class CustomReservationWaitingRepositoryImpl implements CustomReservation
         ));
     }
 
-//    @Override
-//    public Optional<ReservationWaitingWithOrder> findReservationWaitingWithOrder(
-//            final LocalDate date,
-//            final Long memberId,
-//            final Long timeId,
-//            final Long themeId
-//    ) {
-//        final String sql = """
-//                    SELECT
-//                        rw.id AS reservation_waiting_id, rw.date AS reservation_waiting_date, rw.created_at AS reservation_waiting_created_at,
-//                        rt.id AS time_id, rt.start_at AS reservation_time,
-//                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description, th.thumbnail AS theme_thumbnail,
-//                        m.id AS member_id, m.name AS member_name, m.email AS member_email, m.password AS member_password, m.role AS member_role,
-//                        COUNT(rw_sub.id) + 1 AS waiting_order
-//                    FROM
-//                        reservation_waiting rw
-//                    LEFT JOIN
-//                        reservation_waiting rw_sub
-//                    ON
-//                        rw_sub.created_at < rw.created_at
-//                        AND rw_sub.theme_id = rw.theme_id
-//                        AND rw_sub.time_id = rw.time_id
-//                        AND rw_sub.date = rw.date
-//                    INNER JOIN reservation_time AS rt ON rt.id = rw.time_id
-//                    INNER JOIN theme AS th ON th.id = rw.theme_id
-//                    INNER JOIN member AS m ON m.id = rw.member_id
-//                    WHERE rw.date = :date
-//                        AND rw.member_id = :memberId
-//                        AND rw.time_id = :timeId
-//                        AND rw.theme_id = :themeId
-//                    GROUP BY
-//                        rw.id,
-//                        rw.date,
-//                        rw.created_at,
-//                        rw.member_id,
-//                        rw.theme_id,
-//                        rw.time_id;
-//            """;
-//
-//        try {
-//            final MapSqlParameterSource param = new MapSqlParameterSource()
-//                    .addValue("date", date)
-//                    .addValue("memberId", memberId)
-//                    .addValue("timeId", timeId)
-//                    .addValue("themeId", themeId);
-//            final ReservationWaitingWithOrder reservationWaitingWithOrder = template.queryForObject(sql, param, itemRowMapperToReservationWaitingWithOrder());
-//
-//            return Optional.of(reservationWaitingWithOrder);
-//        } catch (final EmptyResultDataAccessException e) {
-//            return Optional.empty();
-//        }
-//    }
-
     @Override
     public Optional<ReservationWaitingWithOrder> findReservationWaitingWithOrder(final Long reservationWaitingId) {
         final String sql = """
-                    SELECT
-                        rw.id AS reservation_waiting_id, rw.date AS reservation_waiting_date, rw.created_at AS reservation_waiting_created_at,
-                        rt.id AS time_id, rt.start_at AS reservation_time,
-                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description, th.thumbnail AS theme_thumbnail,
-                        m.id AS member_id, m.name AS member_name, m.email AS member_email, m.password AS member_password, m.role AS member_role,
-                        COUNT(rw_sub.id) + 1 AS waiting_order
-                    FROM
-                        reservation_waiting rw
-                    LEFT JOIN
-                        reservation_waiting rw_sub
-                    ON
-                        rw_sub.created_at < rw.created_at
-                        AND rw_sub.theme_id = rw.theme_id
-                        AND rw_sub.time_id = rw.time_id
-                        AND rw_sub.date = rw.date
-                    INNER JOIN reservation_time AS rt ON rt.id = rw.time_id
-                    INNER JOIN theme AS th ON th.id = rw.theme_id
-                    INNER JOIN member AS m ON m.id = rw.member_id
-                    WHERE rw.id = :reservationWaitingId
-                    GROUP BY
-                        rw.id,
-                        rw.date,
-                        rw.created_at,
-                        rw.member_id,
-                        rw.theme_id,
-                        rw.time_id;
-            """;
+                        SELECT
+                            rw.id AS reservation_waiting_id, rw.date AS reservation_waiting_date, rw.created_at AS reservation_waiting_created_at,
+                            rt.id AS time_id, rt.start_at AS reservation_time,
+                            th.id AS theme_id, th.name AS theme_name, th.description AS theme_description, th.thumbnail AS theme_thumbnail,
+                            m.id AS member_id, m.name AS member_name, m.email AS member_email, m.password AS member_password, m.role AS member_role,
+                            COUNT(rw_sub.id) + 1 AS waiting_order
+                        FROM
+                            reservation_waiting rw
+                        LEFT JOIN
+                            reservation_waiting rw_sub
+                        ON
+                            rw_sub.created_at < rw.created_at
+                            AND rw_sub.theme_id = rw.theme_id
+                            AND rw_sub.time_id = rw.time_id
+                            AND rw_sub.date = rw.date
+                        INNER JOIN reservation_time AS rt ON rt.id = rw.time_id
+                        INNER JOIN theme AS th ON th.id = rw.theme_id
+                        INNER JOIN member AS m ON m.id = rw.member_id
+                        WHERE rw.id = :reservationWaitingId
+                        GROUP BY
+                            rw.id,
+                            rw.date,
+                            rw.created_at,
+                            rw.member_id,
+                            rw.theme_id,
+                            rw.time_id;
+                """;
 
         try {
             final MapSqlParameterSource param = new MapSqlParameterSource()

--- a/src/main/java/roomescape/domain/reservation/repository/CustomReservationWaitingRepositoryImpl.java
+++ b/src/main/java/roomescape/domain/reservation/repository/CustomReservationWaitingRepositoryImpl.java
@@ -1,5 +1,6 @@
 package roomescape.domain.reservation.repository;
 
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -12,7 +13,9 @@ import roomescape.domain.reservation.model.ReservationWaiting;
 import roomescape.domain.reservation.model.ReservationWaitingWithOrder;
 import roomescape.domain.reservation.model.Theme;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class CustomReservationWaitingRepositoryImpl implements CustomReservationWaitingRepository {
@@ -85,5 +88,100 @@ public class CustomReservationWaitingRepositoryImpl implements CustomReservation
                 ),
                 rs.getInt("waiting_order")
         ));
+    }
+
+//    @Override
+//    public Optional<ReservationWaitingWithOrder> findReservationWaitingWithOrder(
+//            final LocalDate date,
+//            final Long memberId,
+//            final Long timeId,
+//            final Long themeId
+//    ) {
+//        final String sql = """
+//                    SELECT
+//                        rw.id AS reservation_waiting_id, rw.date AS reservation_waiting_date, rw.created_at AS reservation_waiting_created_at,
+//                        rt.id AS time_id, rt.start_at AS reservation_time,
+//                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description, th.thumbnail AS theme_thumbnail,
+//                        m.id AS member_id, m.name AS member_name, m.email AS member_email, m.password AS member_password, m.role AS member_role,
+//                        COUNT(rw_sub.id) + 1 AS waiting_order
+//                    FROM
+//                        reservation_waiting rw
+//                    LEFT JOIN
+//                        reservation_waiting rw_sub
+//                    ON
+//                        rw_sub.created_at < rw.created_at
+//                        AND rw_sub.theme_id = rw.theme_id
+//                        AND rw_sub.time_id = rw.time_id
+//                        AND rw_sub.date = rw.date
+//                    INNER JOIN reservation_time AS rt ON rt.id = rw.time_id
+//                    INNER JOIN theme AS th ON th.id = rw.theme_id
+//                    INNER JOIN member AS m ON m.id = rw.member_id
+//                    WHERE rw.date = :date
+//                        AND rw.member_id = :memberId
+//                        AND rw.time_id = :timeId
+//                        AND rw.theme_id = :themeId
+//                    GROUP BY
+//                        rw.id,
+//                        rw.date,
+//                        rw.created_at,
+//                        rw.member_id,
+//                        rw.theme_id,
+//                        rw.time_id;
+//            """;
+//
+//        try {
+//            final MapSqlParameterSource param = new MapSqlParameterSource()
+//                    .addValue("date", date)
+//                    .addValue("memberId", memberId)
+//                    .addValue("timeId", timeId)
+//                    .addValue("themeId", themeId);
+//            final ReservationWaitingWithOrder reservationWaitingWithOrder = template.queryForObject(sql, param, itemRowMapperToReservationWaitingWithOrder());
+//
+//            return Optional.of(reservationWaitingWithOrder);
+//        } catch (final EmptyResultDataAccessException e) {
+//            return Optional.empty();
+//        }
+//    }
+
+    @Override
+    public Optional<ReservationWaitingWithOrder> findReservationWaitingWithOrder(final Long reservationWaitingId) {
+        final String sql = """
+                    SELECT
+                        rw.id AS reservation_waiting_id, rw.date AS reservation_waiting_date, rw.created_at AS reservation_waiting_created_at,
+                        rt.id AS time_id, rt.start_at AS reservation_time,
+                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description, th.thumbnail AS theme_thumbnail,
+                        m.id AS member_id, m.name AS member_name, m.email AS member_email, m.password AS member_password, m.role AS member_role,
+                        COUNT(rw_sub.id) + 1 AS waiting_order
+                    FROM
+                        reservation_waiting rw
+                    LEFT JOIN
+                        reservation_waiting rw_sub
+                    ON
+                        rw_sub.created_at < rw.created_at
+                        AND rw_sub.theme_id = rw.theme_id
+                        AND rw_sub.time_id = rw.time_id
+                        AND rw_sub.date = rw.date
+                    INNER JOIN reservation_time AS rt ON rt.id = rw.time_id
+                    INNER JOIN theme AS th ON th.id = rw.theme_id
+                    INNER JOIN member AS m ON m.id = rw.member_id
+                    WHERE rw.id = :reservationWaitingId
+                    GROUP BY
+                        rw.id,
+                        rw.date,
+                        rw.created_at,
+                        rw.member_id,
+                        rw.theme_id,
+                        rw.time_id;
+            """;
+
+        try {
+            final MapSqlParameterSource param = new MapSqlParameterSource()
+                    .addValue("reservationWaitingId", reservationWaitingId);
+            final ReservationWaitingWithOrder reservationWaitingWithOrder = template.queryForObject(sql, param, itemRowMapperToReservationWaitingWithOrder());
+
+            return Optional.of(reservationWaitingWithOrder);
+        } catch (final EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/roomescape/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/domain/reservation/repository/ReservationRepository.java
@@ -3,6 +3,7 @@ package roomescape.domain.reservation.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import roomescape.domain.reservation.model.Reservation;
 import roomescape.domain.reservation.model.ReservationDate;
+import roomescape.domain.reservation.model.ReservationStatus;
 
 import java.util.List;
 
@@ -13,6 +14,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     boolean existsByTimeId(Long reservationTimeId);
 
     boolean existsByThemeId(Long themeId);
+
+    boolean existsByDateAndTime_IdAndTheme_IdAndStatus(ReservationDate date, Long time_id, Long theme_id, ReservationStatus status);
 
     List<Reservation> findAllByDateAndTheme_Id(ReservationDate date, Long themeId);
 

--- a/src/main/java/roomescape/domain/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ReservationService.java
@@ -88,7 +88,7 @@ public class ReservationService {
                 .orElseThrow(() -> new NoSuchElementException("해당 id의 테마가 존재하지 않습니다."));
         final Member member = memberRepository.findById(request.memberId())
                 .orElseThrow(() -> new NoSuchElementException("해당 id의 회원이 존재하지 않습니다."));
-        final Reservation reservation = request.toReservation(reservationTime, theme, member);
+        final Reservation reservation = request.toModel(reservationTime, theme, member);
 
         validateReservationDateAndTime(reservation.getDate(), reservationTime);
         validateReservationDuplicated(reservation);
@@ -120,7 +120,7 @@ public class ReservationService {
                 .orElseThrow(() -> new NoSuchElementException("해당 id의 테마가 존재하지 않습니다."));
         final Member member = memberRepository.findById(request.memberId())
                 .orElseThrow(() -> new NoSuchElementException("해당 id의 회원이 존재하지 않습니다."));
-        final Reservation reservation = request.toReservation(reservationTime, theme, member);
+        final Reservation reservation = request.toModel(reservationTime, theme, member);
 
         validateReservationDateAndTime(reservation.getDate(), reservationTime);
         validateReservationDuplicated(reservation);
@@ -170,6 +170,6 @@ public class ReservationService {
         final PaymentHistory paymentHistory = paymentHistoryRepository.findByReservation(reservation)
                 .orElseThrow(() -> new NoSuchElementException("해당 예약의 결제 정보가 존재하지 않습니다."));
 
-        return ReservationWithPaymentHistoryDto.from(reservation, paymentHistory.getPaymentKey(), paymentHistory.getTotalAmount());
+        return ReservationWithPaymentHistoryDto.of(reservation, paymentHistory.getPaymentKey(), paymentHistory.getTotalAmount());
     }
 }

--- a/src/main/java/roomescape/domain/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ReservationService.java
@@ -11,7 +11,7 @@ import roomescape.domain.payment.service.PaymentService;
 import roomescape.domain.reservation.dto.ReservationDto;
 import roomescape.domain.reservation.dto.ReservationWithPaymentHistoryDto;
 import roomescape.domain.reservation.dto.SaveAdminReservationRequest;
-import roomescape.domain.reservation.dto.SavePaymentHistoryRequest;
+import roomescape.domain.reservation.dto.PaymentHistoryDto;
 import roomescape.domain.reservation.dto.SaveReservationRequest;
 import roomescape.domain.reservation.dto.SearchReservationsParams;
 import roomescape.domain.reservation.dto.SearchReservationsRequest;
@@ -88,8 +88,8 @@ public class ReservationService {
         validateReservationDateAndTime(reservation.getDate(), reservation.getTime());
         validateReservationDuplicated(reservation);
 
-        final SavePaymentHistoryRequest savePaymentHistoryRequest = convertPaymentHistoryRequest(request, reservation);
-        paymentService.savePaymentHistory(savePaymentHistoryRequest);
+        final PaymentHistoryDto paymentHistoryDto = convertPaymentHistoryRequest(request, reservation);
+        paymentService.savePaymentHistory(paymentHistoryDto);
 
         return ReservationDto.from(reservationRepository.save(reservation));
     }
@@ -128,8 +128,8 @@ public class ReservationService {
                 .orElseThrow(() -> new NoSuchElementException("해당 id의 예약 시간이 존재하지 않습니다."));
     }
 
-    private SavePaymentHistoryRequest convertPaymentHistoryRequest(final SaveAdminReservationRequest request, final Reservation reservation) {
-        return new SavePaymentHistoryRequest(
+    private PaymentHistoryDto convertPaymentHistoryRequest(final SaveAdminReservationRequest request, final Reservation reservation) {
+        return new PaymentHistoryDto(
                 request.orderId(),
                 PaymentStatus.DONE,
                 request.orderName(),

--- a/src/main/java/roomescape/domain/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ReservationService.java
@@ -75,6 +75,7 @@ public class ReservationService {
                 .toList();
     }
 
+    @Transactional
     public ReservationDto saveReservation(final SaveReservationRequest request) {
         final ReservationTime reservationTime = reservationTimeRepository.findById(request.timeId())
                 .orElseThrow(() -> new NoSuchElementException("해당 id의 예약 시간이 존재하지 않습니다."));
@@ -87,9 +88,11 @@ public class ReservationService {
         validateReservationDateAndTime(reservation.getDate(), reservationTime);
         validateReservationDuplicated(reservation);
 
-        paymentService.submitPayment(request.orderId(), request.amount(), request.paymentKey(), member);
+        final Reservation savedReservation = reservationRepository.save(reservation);
 
-        return ReservationDto.from(reservationRepository.save(reservation));
+        paymentService.submitPayment(request.orderId(), request.amount(), request.paymentKey(), savedReservation);
+
+        return ReservationDto.from(savedReservation);
     }
 
     private static void validateReservationDateAndTime(final ReservationDate date, final ReservationTime time) {

--- a/src/main/java/roomescape/domain/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ReservationService.java
@@ -130,7 +130,6 @@ public class ReservationService {
 
     private PaymentHistoryDto convertPaymentHistoryRequest(final SaveAdminReservationRequest request, final Reservation reservation) {
         return new PaymentHistoryDto(
-                request.orderId(),
                 PaymentStatus.DONE,
                 request.orderName(),
                 request.amount(),

--- a/src/main/java/roomescape/domain/reservation/service/ReservationTimeService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ReservationTimeService.java
@@ -37,7 +37,7 @@ public class ReservationTimeService {
     public ReservationTimeDto saveReservationTime(final SaveReservationTimeRequest request) {
         validateReservationTimeDuplication(request);
 
-        final ReservationTime savedReservationTime = reservationTimeRepository.save(request.toReservationTime());
+        final ReservationTime savedReservationTime = reservationTimeRepository.save(request.toModel());
         return ReservationTimeDto.from(savedReservationTime);
     }
 

--- a/src/main/java/roomescape/domain/reservation/service/ReservationWaitingService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ReservationWaitingService.java
@@ -68,7 +68,7 @@ public class ReservationWaitingService {
     public List<ReservationWaitingWithOrderDto> getMyReservationWaiting(final Long memberId) {
         return customReservationWaitingRepository.findAllReservationWaitingWithOrdersByMemberId(memberId)
                 .stream()
-                .map(reservationWaitingWithOrder -> ReservationWaitingWithOrderDto.from(reservationWaitingWithOrder, checkPaymentAvailable(reservationWaitingWithOrder)))
+                .map(reservationWaitingWithOrder -> ReservationWaitingWithOrderDto.of(reservationWaitingWithOrder, checkPaymentAvailable(reservationWaitingWithOrder)))
                 .toList();
     }
 

--- a/src/main/java/roomescape/domain/reservation/service/ReservationWaitingService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ReservationWaitingService.java
@@ -1,15 +1,21 @@
 package roomescape.domain.reservation.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import roomescape.domain.member.model.Member;
 import roomescape.domain.member.repository.MemberRepository;
+import roomescape.domain.reservation.dto.ApproveReservationWaitingRequest;
+import roomescape.domain.reservation.dto.ReservationDto;
 import roomescape.domain.reservation.dto.ReservationWaitingDto;
 import roomescape.domain.reservation.dto.ReservationWaitingWithOrderDto;
+import roomescape.domain.reservation.dto.SaveReservationRequest;
 import roomescape.domain.reservation.dto.SaveReservationWaitingRequest;
 import roomescape.domain.reservation.exception.InvalidReservationWaitInputException;
 import roomescape.domain.reservation.model.ReservationDate;
+import roomescape.domain.reservation.model.ReservationStatus;
 import roomescape.domain.reservation.model.ReservationTime;
 import roomescape.domain.reservation.model.ReservationWaiting;
+import roomescape.domain.reservation.model.ReservationWaitingWithOrder;
 import roomescape.domain.reservation.model.Theme;
 import roomescape.domain.reservation.repository.CustomReservationWaitingRepository;
 import roomescape.domain.reservation.repository.ReservationRepository;
@@ -24,12 +30,15 @@ import java.util.NoSuchElementException;
 @Service
 public class ReservationWaitingService {
 
+    private static final int FIRST_RESERVATION_WAITING_ORDER_VALUE = 1;
+
     private final ReservationWaitingRepository reservationWaitingRepository;
     private final CustomReservationWaitingRepository customReservationWaitingRepository;
     private final ReservationRepository reservationRepository;
     private final MemberRepository memberRepository;
     private final ThemeRepository themeRepository;
     private final ReservationTimeRepository reservationTimeRepository;
+    private final ReservationService reservationService;
 
     public ReservationWaitingService(
             final CustomReservationWaitingRepository customReservationWaitingRepository,
@@ -37,7 +46,8 @@ public class ReservationWaitingService {
             final ReservationRepository reservationRepository,
             final MemberRepository memberRepository,
             final ThemeRepository themeRepository,
-            final ReservationTimeRepository reservationTimeRepository
+            final ReservationTimeRepository reservationTimeRepository,
+            final ReservationService reservationService
     ) {
         this.customReservationWaitingRepository = customReservationWaitingRepository;
         this.reservationWaitingRepository = reservationWaitingRepository;
@@ -45,6 +55,7 @@ public class ReservationWaitingService {
         this.memberRepository = memberRepository;
         this.themeRepository = themeRepository;
         this.reservationTimeRepository = reservationTimeRepository;
+        this.reservationService = reservationService;
     }
 
     public List<ReservationWaitingDto> getAllReservationWaiting() {
@@ -57,8 +68,24 @@ public class ReservationWaitingService {
     public List<ReservationWaitingWithOrderDto> getMyReservationWaiting(final Long memberId) {
         return customReservationWaitingRepository.findAllReservationWaitingWithOrdersByMemberId(memberId)
                 .stream()
-                .map(ReservationWaitingWithOrderDto::from)
+                .map(reservationWaitingWithOrder -> ReservationWaitingWithOrderDto.from(reservationWaitingWithOrder, checkPaymentAvailable(reservationWaitingWithOrder)))
                 .toList();
+    }
+
+    private boolean checkPaymentAvailable(final ReservationWaitingWithOrder reservationWaitingWithOrder) {
+        if (reservationWaitingWithOrder.getOrder() != FIRST_RESERVATION_WAITING_ORDER_VALUE) {
+            return false;
+        }
+
+        final ReservationWaiting reservationWaiting = reservationWaitingWithOrder.getReservationWaiting();
+        final boolean existReservation = reservationRepository.existsByDateAndTime_IdAndTheme_IdAndStatus(
+                reservationWaiting.getDate(),
+                reservationWaiting.getTime().getId(),
+                reservationWaiting.getTheme().getId(),
+                ReservationStatus.RESERVATION
+        );
+
+        return !existReservation;
     }
 
     public Long saveReservationWaiting(final SaveReservationWaitingRequest request) {
@@ -89,7 +116,14 @@ public class ReservationWaitingService {
             final ReservationDate date,
             final ReservationTime reservationTime
     ) {
-        if (!reservationRepository.existsByDateAndTime_IdAndTheme_Id(date, reservationTime.getId(), theme.getId())) {
+        final boolean existReservation = reservationRepository.existsByDateAndTime_IdAndTheme_IdAndStatus(
+                date,
+                reservationTime.getId(),
+                theme.getId(),
+                ReservationStatus.RESERVATION
+        );
+
+        if (!existReservation) {
             throw new InvalidReservationWaitInputException("존재하지 않는 예약에 대한 대기 신청을 할 수 없습니다.");
         }
     }
@@ -107,5 +141,37 @@ public class ReservationWaitingService {
 
     public void deleteReservationWaiting(final Long reservationWaitingId) {
         reservationWaitingRepository.deleteById(reservationWaitingId);
+    }
+
+    @Transactional
+    public ReservationDto approveReservationWaiting(final ApproveReservationWaitingRequest request) {
+        final ReservationWaitingWithOrder reservationWaitingWithOrder = customReservationWaitingRepository.findReservationWaitingWithOrder(request.reservationWaitingId())
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 예약 대기 정보입니다."));
+
+        validateReservationWaiting(reservationWaitingWithOrder);
+        final SaveReservationRequest saveReservationRequest = convertSaveReservationRequest(request, reservationWaitingWithOrder);
+        final ReservationDto reservationDto = reservationService.saveReservation(saveReservationRequest);
+        deleteReservationWaiting(reservationWaitingWithOrder.getReservationWaiting().getId());
+
+        return reservationDto;
+    }
+
+    private void validateReservationWaiting(final ReservationWaitingWithOrder reservationWaitingWithOrder) {
+        if (!checkPaymentAvailable(reservationWaitingWithOrder)) {
+            throw new IllegalStateException("결제할 수 없는 예약 대기 입니다.");
+        }
+    }
+
+    private SaveReservationRequest convertSaveReservationRequest(final ApproveReservationWaitingRequest request, final ReservationWaitingWithOrder reservationWaitingWithOrder) {
+        final ReservationWaiting reservationWaiting = reservationWaitingWithOrder.getReservationWaiting();
+        return new SaveReservationRequest(
+                reservationWaiting.getDate().getValue(),
+                reservationWaiting.getMember().getId(),
+                reservationWaiting.getTime().getId(),
+                reservationWaiting.getTheme().getId(),
+                request.orderId(),
+                request.amount(),
+                request.paymentKey()
+        );
     }
 }

--- a/src/main/java/roomescape/domain/reservation/service/ReservationWaitingService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ReservationWaitingService.java
@@ -30,8 +30,6 @@ import java.util.NoSuchElementException;
 @Service
 public class ReservationWaitingService {
 
-    private static final int FIRST_RESERVATION_WAITING_ORDER_VALUE = 1;
-
     private final ReservationWaitingRepository reservationWaitingRepository;
     private final CustomReservationWaitingRepository customReservationWaitingRepository;
     private final ReservationRepository reservationRepository;
@@ -73,11 +71,11 @@ public class ReservationWaitingService {
     }
 
     private boolean checkPaymentAvailable(final ReservationWaitingWithOrder reservationWaitingWithOrder) {
-        if (reservationWaitingWithOrder.getOrder() != FIRST_RESERVATION_WAITING_ORDER_VALUE) {
+        if (!reservationWaitingWithOrder.isFirstOrder()) {
             return false;
         }
 
-        final ReservationWaiting reservationWaiting = reservationWaitingWithOrder.getReservationWaiting();
+        final ReservationWaiting reservationWaiting = reservationWaitingWithOrder.reservationWaiting();
         final boolean existReservation = reservationRepository.existsByDateAndTime_IdAndTheme_IdAndStatus(
                 reservationWaiting.getDate(),
                 reservationWaiting.getTime().getId(),
@@ -151,7 +149,7 @@ public class ReservationWaitingService {
         validateReservationWaiting(reservationWaitingWithOrder);
         final SaveReservationRequest saveReservationRequest = convertSaveReservationRequest(request, reservationWaitingWithOrder);
         final ReservationDto reservationDto = reservationService.saveReservationWithPaymentConfirm(saveReservationRequest);
-        deleteReservationWaiting(reservationWaitingWithOrder.getReservationWaiting().getId());
+        deleteReservationWaiting(reservationWaitingWithOrder.reservationWaiting().getId());
 
         return reservationDto;
     }
@@ -163,7 +161,7 @@ public class ReservationWaitingService {
     }
 
     private SaveReservationRequest convertSaveReservationRequest(final ApproveReservationWaitingRequest request, final ReservationWaitingWithOrder reservationWaitingWithOrder) {
-        final ReservationWaiting reservationWaiting = reservationWaitingWithOrder.getReservationWaiting();
+        final ReservationWaiting reservationWaiting = reservationWaitingWithOrder.reservationWaiting();
         return new SaveReservationRequest(
                 reservationWaiting.getDate().getValue(),
                 reservationWaiting.getMember().getId(),

--- a/src/main/java/roomescape/domain/reservation/service/ReservationWaitingService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ReservationWaitingService.java
@@ -150,7 +150,7 @@ public class ReservationWaitingService {
 
         validateReservationWaiting(reservationWaitingWithOrder);
         final SaveReservationRequest saveReservationRequest = convertSaveReservationRequest(request, reservationWaitingWithOrder);
-        final ReservationDto reservationDto = reservationService.saveReservation(saveReservationRequest);
+        final ReservationDto reservationDto = reservationService.saveReservationWithPaymentConfirm(saveReservationRequest);
         deleteReservationWaiting(reservationWaitingWithOrder.getReservationWaiting().getId());
 
         return reservationDto;

--- a/src/main/java/roomescape/domain/reservation/service/ThemeService.java
+++ b/src/main/java/roomescape/domain/reservation/service/ThemeService.java
@@ -37,7 +37,7 @@ public class ThemeService {
     }
 
     public ThemeDto saveTheme(final SaveThemeRequest saveThemeRequest) {
-        final Theme savedTheme = themeRepository.save(saveThemeRequest.toTheme());
+        final Theme savedTheme = themeRepository.save(saveThemeRequest.toModel());
         return ThemeDto.from(savedTheme);
     }
 

--- a/src/main/java/roomescape/web/AdminWebController.java
+++ b/src/main/java/roomescape/web/AdminWebController.java
@@ -8,26 +8,26 @@ public class AdminWebController {
 
     @GetMapping("/admin")
     public String getAdminPage() {
-        return "/admin/index";
+        return "admin/index";
     }
 
     @GetMapping("/admin/reservation")
     public String getReservationPage() {
-        return "/admin/reservation-new";
+        return "admin/reservation-new";
     }
 
     @GetMapping("/admin/time")
     public String getTimePage() {
-        return "/admin/time";
+        return "admin/time";
     }
 
     @GetMapping("/admin/theme")
     public String getThemePage() {
-        return "/admin/theme";
+        return "admin/theme";
     }
 
     @GetMapping("/admin/waiting")
     public String getWaitingPage() {
-        return "/admin/waiting";
+        return "admin/waiting";
     }
 }

--- a/src/main/java/roomescape/web/UserWebController.java
+++ b/src/main/java/roomescape/web/UserWebController.java
@@ -8,26 +8,26 @@ public class UserWebController {
 
     @GetMapping("/login")
     public String getLoginPage() {
-        return "/login";
+        return "login";
     }
 
     @GetMapping("/signup")
     public String getSingUpPage() {
-        return "/signup";
+        return "signup";
     }
 
     @GetMapping
     public String getPopularThemePage() {
-        return "/index";
+        return "index";
     }
 
     @GetMapping("/reservation")
     public String getUserReservationPage() {
-        return "/reservation";
+        return "reservation";
     }
 
     @GetMapping("/reservation-mine")
     public String getUserMyReservationPage() {
-        return "/reservation-mine";
+        return "reservation-mine";
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -121,3 +121,40 @@ INSERT INTO reservation_waiting(member_id, date, time_id, theme_id, created_at)
 VALUES (3, CAST(TIMESTAMPADD(DAY, 6, NOW()) AS DATE), 3, 8, CAST(TIMESTAMPADD(MINUTE, 50, CURRENT_TIMESTAMP()) AS DATETIME));
 INSERT INTO reservation_waiting(member_id, date, time_id, theme_id, created_at)
 VALUES (2, CAST(TIMESTAMPADD(DAY, 6, NOW()) AS DATE), 3, 8, CAST(TIMESTAMPADD(MINUTE, 1, CURRENT_TIMESTAMP()) AS DATETIME));
+
+/**
+  Payment History
+ */
+
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (1, 'test_order_id_1', 'gen_test_payment_key_1', 'test_order_name', 'DONE', 30000, '토스페이', NOW());
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (2, 'test_order_id_2', 'gen_test_payment_key_2', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (3, 'test_order_id_3', 'gen_test_payment_key_3', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (4, 'test_order_id_4', 'gen_test_payment_key_4', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (5, 'test_order_id_5', 'gen_test_payment_key_5', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (6, 'test_order_id_6', 'gen_test_payment_key_6', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (7, 'test_order_id_7', 'gen_test_payment_key_7', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (8, 'test_order_id_8', 'gen_test_payment_key_8', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (9, 'test_order_id_9', 'gen_test_payment_key_9', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (10, 'test_order_id_10', 'gen_test_payment_key_10', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (11, 'test_order_id_11', 'gen_test_payment_key_11', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (12, 'test_order_id_12', 'gen_test_payment_key_12', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (13, 'test_order_id_13', 'gen_test_payment_key_13', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (14, 'test_order_id_14', 'gen_test_payment_key_14', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (15, 'test_order_id_15', 'gen_test_payment_key_15', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (16, 'test_order_id_16', 'gen_test_payment_key_16', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -126,35 +126,35 @@ VALUES (2, CAST(TIMESTAMPADD(DAY, 6, NOW()) AS DATE), 3, 8, CAST(TIMESTAMPADD(MI
   Payment History
  */
 
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (1, 'test_order_id_1', 'gen_test_payment_key_1', 'test_order_name', 'DONE', 30000, '토스페이', NOW());
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (2, 'test_order_id_2', 'gen_test_payment_key_2', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (3, 'test_order_id_3', 'gen_test_payment_key_3', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (4, 'test_order_id_4', 'gen_test_payment_key_4', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (5, 'test_order_id_5', 'gen_test_payment_key_5', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (6, 'test_order_id_6', 'gen_test_payment_key_6', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (7, 'test_order_id_7', 'gen_test_payment_key_7', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (8, 'test_order_id_8', 'gen_test_payment_key_8', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (9, 'test_order_id_9', 'gen_test_payment_key_9', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (10, 'test_order_id_10', 'gen_test_payment_key_10', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (11, 'test_order_id_11', 'gen_test_payment_key_11', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (12, 'test_order_id_12', 'gen_test_payment_key_12', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (13, 'test_order_id_13', 'gen_test_payment_key_13', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (14, 'test_order_id_14', 'gen_test_payment_key_14', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (15, 'test_order_id_15', 'gen_test_payment_key_15', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (16, 'test_order_id_16', 'gen_test_payment_key_16', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (1, 'gen_test_payment_key_1', 'test_order_name', 'DONE', 30000, '토스페이', NOW());
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (2, 'gen_test_payment_key_2', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (3, 'gen_test_payment_key_3', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (4, 'gen_test_payment_key_4', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (5, 'gen_test_payment_key_5', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (6, 'gen_test_payment_key_6', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (7, 'gen_test_payment_key_7', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (8, 'gen_test_payment_key_8', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (9, 'gen_test_payment_key_9', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (10, 'gen_test_payment_key_10', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (11, 'gen_test_payment_key_11', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (12, 'gen_test_payment_key_12', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (13, 'gen_test_payment_key_13', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (14, 'gen_test_payment_key_14', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (15, 'gen_test_payment_key_15', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (16, 'gen_test_payment_key_16', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));

--- a/src/main/resources/static/js/reservation-mine.js
+++ b/src/main/resources/static/js/reservation-mine.js
@@ -4,6 +4,25 @@ document.addEventListener('DOMContentLoaded', async () => {
     ...await getMyReservationWaiting()
   ];
   render(data);
+
+  // ------  결제위젯 초기화 ------
+  // @docs https://docs.tosspayments.com/reference/widget-sdk#sdk-설치-및-초기화
+  // @docs https://docs.tosspayments.com/reference/widget-sdk#renderpaymentmethods선택자-결제-금액-옵션
+  const paymentAmount = 13500;
+  const widgetClientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
+  const paymentWidget = PaymentWidget(widgetClientKey, PaymentWidget.ANONYMOUS);
+
+  paymentWidget.renderPaymentMethods(
+    "#payment-method",
+    {value: paymentAmount},
+    {variantKey: "DEFAULT"}
+  );
+
+  document.getElementById('content-container').style.display = 'none';
+  document.getElementById('reserve-button').addEventListener('click', onReservationButtonClickWithPaymentWidget);
+  function onReservationButtonClickWithPaymentWidget(event) {
+    onReservationButtonClick(paymentWidget);
+  }
 });
 
 function getMyReservations() {
@@ -24,6 +43,14 @@ function getMyReservationWaiting() {
     .catch(error => console.error('Error fetching reservation waiting:', error));
 }
 
+function createWaitingStatus(item) {
+  if (item.paymentAvailable) {
+    return "결제 대기";
+  }
+
+  return item.order + "번째 예약대기";
+}
+
 function render(data) {
   const tableBody = document.getElementById('table-body');
   tableBody.innerHTML = '';
@@ -33,23 +60,15 @@ function render(data) {
     const theme = item.theme;
     const date = item.date;
     const time = item.time;
-    const status = (item["order"] !== undefined) ? item.order + "번째 예약대기" : item.status;
+    const status = (item["order"] !== undefined) ? createWaitingStatus(item) : item.status;
+    const paymentAvailable = (item["paymentAvailable"] !== undefined) ? item.paymentAvailable  : false;
 
     row.insertCell(0).textContent = theme;
     row.insertCell(1).textContent = date;
     row.insertCell(2).textContent = time;
     row.insertCell(3).textContent = status;
 
-    if (status !== '예약') { // 예약 대기 상태일 때 예약 대기 취소 버튼 추가하는 코드, 상태 값은 변경 가능
-      const cancelCell = row.insertCell(4);
-      const cancelButton = document.createElement('button');
-      cancelButton.textContent = '취소';
-      cancelButton.className = 'btn btn-danger';
-      cancelButton.onclick = function () {
-        requestDeleteWaiting(item.id).then(() => window.location.reload());
-      };
-      cancelCell.appendChild(cancelButton);
-    } else { // 예약 완료 상태일 때
+    if (status === "예약" || status === "취소") { // 예약 완료 상태일 때
       /*
       TODO: [미션4 - 2단계] 내 예약 목록 조회 시,
        예약 완료 상태일 때 결제 정보를 함께 보여주기
@@ -58,6 +77,27 @@ function render(data) {
       row.insertCell(4).textContent = '';
       row.insertCell(5).textContent = item.paymentKey;
       row.insertCell(6).textContent = item.amount;
+    } else {
+      if (paymentAvailable === true) {
+        const paymentCell = row.insertCell(4);
+        const paymentButton = document.createElement('button');
+        paymentButton.textContent = '결제';
+        paymentButton.style.backgroundColor = 'blue';
+        paymentButton.className = 'btn btn-danger';
+        paymentButton.onclick = function () {
+          onPaymentButtonClick(item.id);
+        };
+        paymentCell.appendChild(paymentButton);
+      } else {
+        const cancelCell = row.insertCell(4);
+        const cancelButton = document.createElement('button');
+        cancelButton.textContent = '취소';
+        cancelButton.className = 'btn btn-danger';
+        cancelButton.onclick = function () {
+          requestDeleteWaiting(item.id).then(() => window.location.reload());
+        };
+        cancelCell.appendChild(cancelButton);
+      }
     }
   });
 }
@@ -69,5 +109,92 @@ function requestDeleteWaiting(id) {
   }).then(response => {
     if (response.status === 204) return;
     throw new Error('Delete failed');
+  });
+}
+
+let paymentReservationWaitingId = undefined;
+function onPaymentButtonClick(reservationWaitingId) {
+  paymentReservationWaitingId = reservationWaitingId;
+  document.getElementById('content-container').style.display = 'block';
+  alert(`결제 준비 완료!\n예약 대기 아이디 : ${paymentReservationWaitingId}`);
+}
+
+function onReservationButtonClick(paymentWidget) {
+  if (paymentReservationWaitingId === undefined) {
+    alert("결제 대기 정보가 유효하지 않습니다.");
+    return;
+  }
+
+  const generateRandomString = () => window.btoa(Math.random()).slice(0, 20);
+  // TOSS 결제 위젯 Javascript SDK 연동 방식 중 'Promise로 처리하기'를 적용함
+  // https://docs.tosspayments.com/reference/widget-sdk#promise%EB%A1%9C-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0
+  const orderIdPrefix = "kelly_daon";
+  const orderId = orderIdPrefix + generateRandomString();
+  const orderName = "테스트 방탈출 예약 결제 1건";
+  const amount = 13500;
+
+  // 1. 서버에 임시 저장 요청
+  fetch("/payments/credentials", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({orderId, amount}),
+  }).then(response => {
+    if (!response.ok) {
+      throw Error("서버에 결제 정보가 임시 저장되지 않음.")
+    } else {
+      console.log("결제 정보 임시 저장 성공");
+    }
+  }).catch(error => {
+    console.error(error.message);
+  });
+
+  // 2. 결제 인증 요청
+  paymentWidget.requestPayment({
+    orderId,
+    orderName,
+    amount,
+  }).then(function (data) {
+    console.debug(data);
+    // 3. 결제 승인 요청
+    fetchReservationWaitingPaymentApprove(data, paymentReservationWaitingId);
+  }).catch(function (error) {
+    // TOSS 에러 처리: 에러 목록을 확인하세요
+    // https://docs.tosspayments.com/reference/error-codes#failurl 로-전달되는-에러
+    alert(error.code + " :" + error.message + "/ orderId : " + error.orderId);
+  });
+}
+
+async function fetchReservationWaitingPaymentApprove(paymentData, reservationWaitingId) {
+  const reservationWaitingPaymentApproveRequest = {
+    reservationWaitingId,
+    orderId: paymentData.orderId,
+    amount: paymentData.amount,
+    paymentKey: paymentData.paymentKey,
+    paymentType: paymentData.paymentType,
+  }
+
+  const reservationWaitingPaymentApproveURL = "/reservation-waiting/approve";
+  fetch(reservationWaitingPaymentApproveURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(reservationWaitingPaymentApproveRequest),
+  }).then(response => {
+    if (!response.ok) {
+      return response.json().then(errorBody => {
+        console.error("예약 대기 결제 실패 : " + JSON.stringify(errorBody));
+        window.alert(JSON.stringify(errorBody));
+      });
+    } else {
+      response.json().then(successBody => {
+        console.log("예약 대기 결제 성공 : " + JSON.stringify(successBody));
+        window.location.reload();
+      });
+    }
+  }).catch(error => {
+    console.error(error.message);
   });
 }

--- a/src/main/resources/static/js/reservation-mine.js
+++ b/src/main/resources/static/js/reservation-mine.js
@@ -50,7 +50,14 @@ function render(data) {
       };
       cancelCell.appendChild(cancelButton);
     } else { // 예약 완료 상태일 때
+      /*
+      TODO: [미션4 - 2단계] 내 예약 목록 조회 시,
+       예약 완료 상태일 때 결제 정보를 함께 보여주기
+       결제 정보 필드명은 자신의 response 에 맞게 변경하기
+     */
       row.insertCell(4).textContent = '';
+      row.insertCell(5).textContent = item.paymentKey;
+      row.insertCell(6).textContent = item.amount;
     }
   });
 }

--- a/src/main/resources/static/js/reservation-with-member.js
+++ b/src/main/resources/static/js/reservation-with-member.js
@@ -25,6 +25,10 @@ function render(data) {
   tableBody.innerHTML = '';
 
   data.forEach(item => {
+    if (item.status !== "예약") {
+      return;
+    }
+
     const row = tableBody.insertRow();
 
     row.insertCell(0).textContent = item.id;              // 예약 id

--- a/src/main/resources/static/js/reservation-with-member.js
+++ b/src/main/resources/static/js/reservation-with-member.js
@@ -1,6 +1,6 @@
 let isEditing = false;
 const RESERVATION_API_ENDPOINT = '/admin/reservations';
-const TIME_API_ENDPOINT = '/times';
+const TIME_API_ENDPOINT = '/admin/times';
 const THEME_API_ENDPOINT = '/themes';
 const MEMBER_API_ENDPOINT = '/admin/members';
 const timesOptions = [];
@@ -209,10 +209,24 @@ function applyFilter(event) {
 }
 
 function requestCreate(reservation) {
+  const generateRandomString = () => window.btoa(Math.random()).slice(0, 20);
+  const orderIdPrefix = "kelly_daon";
+  const orderId = orderIdPrefix + generateRandomString();
+  const paymentKey = "admin_payment_" + generateRandomString();
+  const adminReservationRequest = {
+    date: reservation.date,
+    memberId: reservation.memberId,
+    timeId: reservation.timeId,
+    themeId: reservation.themeId,
+    orderId,
+    orderName: "관리자 방탈출 주문",
+    amount: 15000,
+    paymentKey
+  }
   const requestOptions = {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(reservation)
+    body: JSON.stringify(adminReservationRequest)
   };
 
   return fetch('/admin/reservations', requestOptions)

--- a/src/main/resources/static/js/time.js
+++ b/src/main/resources/static/js/time.js
@@ -1,5 +1,5 @@
 let isEditing = false;
-const API_ENDPOINT = '/times';
+const API_ENDPOINT = '/admin/times';
 const cellFields = ['id', 'startAt'];
 const createCellFields = ['', createInput()];
 function createBody(inputs) {

--- a/src/main/resources/templates/reservation-mine.html
+++ b/src/main/resources/templates/reservation-mine.html
@@ -53,6 +53,9 @@
       <th>날짜</th>
       <th>시간</th>
       <th>상태</th>
+      <th>대기 취소</th>
+      <th>paymentKey</th>
+      <th>결제금액</th>
       <th></th>
     </tr>
     </thead>

--- a/src/main/resources/templates/reservation-mine.html
+++ b/src/main/resources/templates/reservation-mine.html
@@ -7,6 +7,8 @@
   <!-- Bootstrap CSS -->
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/toss-style.css">
+  <script src="https://js.tosspayments.com/v1/payment-widget"></script>
 </head>
 <body>
 
@@ -62,6 +64,19 @@
     <tbody id="table-body">
     </tbody>
   </table>
+</div>
+
+<div id="content-container" class="col-md-10 offset-md-1 p-5">
+
+  <div class="wrapper w-100">
+    <div class="max-w-540 w-100">
+      <div id="payment-method" class="w-100"></div>
+      <div id="agreement" class="w-100"></div>
+      <div class="btn-wrapper w-100">
+        <button id="reserve-button" class="btn primary w-100">예약하기</button>
+      </div>
+    </div>
+  </div>
 </div>
 
 <script src="/js/user-scripts.js"></script>

--- a/src/test/java/roomescape/domain/payment/pg/FakePaymentGateway.java
+++ b/src/test/java/roomescape/domain/payment/pg/FakePaymentGateway.java
@@ -2,7 +2,6 @@ package roomescape.domain.payment.pg;
 
 import org.springframework.boot.test.context.TestComponent;
 import roomescape.domain.payment.dto.PaymentConfirmResponse;
-import roomescape.domain.payment.pg.PaymentGateway;
 
 import java.util.Map;
 
@@ -17,6 +16,7 @@ public class FakePaymentGateway implements PaymentGateway {
                 "테스트 결제",
                 10000L,
                 "2024-02-13T12:18:14+09:00",
+                "tgen_test_payment_key",
                 Map.of("provider", "토스페이")
         );
     }

--- a/src/test/java/roomescape/domain/reservation/controller/AdminReservationControllerTest.java
+++ b/src/test/java/roomescape/domain/reservation/controller/AdminReservationControllerTest.java
@@ -15,6 +15,7 @@ import roomescape.config.TestConfig;
 import roomescape.domain.member.model.MemberRole;
 import roomescape.domain.reservation.dto.ReservationResponse;
 import roomescape.domain.reservation.dto.ReservationTimeResponse;
+import roomescape.domain.reservation.dto.SaveAdminReservationRequest;
 import roomescape.domain.reservation.dto.SaveReservationRequest;
 import roomescape.domain.reservation.dto.SaveReservationTimeRequest;
 import roomescape.domain.reservation.dto.SaveThemeRequest;
@@ -58,12 +59,13 @@ class AdminReservationControllerTest {
     @DisplayName("(관리자) - 사용자 아이디를 포함하여 예약 정보를 저장한다.")
     @Test
     void saveReservationForAdminTest() {
-        final SaveReservationRequest saveReservationRequest = new SaveReservationRequest(
+        final SaveAdminReservationRequest saveReservationRequest = new SaveAdminReservationRequest(
                 LocalDate.now().plusDays(1),
                 3L,
                 1L,
                 1L,
                 "test-order-id",
+                "test_order_name",
                 10000L,
                 "test_payment_key"
         );
@@ -117,7 +119,10 @@ class AdminReservationControllerTest {
                 .statusCode(200).extract()
                 .jsonPath().getList(".", ReservationResponse.class);
 
-        assertThat(reservations.size()).isEqualTo(15);
+        final boolean isCancel = reservations.stream()
+                .anyMatch(reservationResponse -> reservationResponse.status().equals("취소"));
+
+        assertThat(isCancel).isTrue();
     }
 
     @DisplayName("관리자가 아닌 클라이언트가 예약 정보를 삭제하려고 하면 에러 코드가 응답된다.")
@@ -174,7 +179,7 @@ class AdminReservationControllerTest {
         // 예약 시간 정보 조회
         final List<ReservationTimeResponse> reservationTimes = RestAssured.given().log().all()
                 .cookie("token", createAdminAccessToken())
-                .when().get("/times")
+                .when().get("/admin/times")
                 .then().log().all()
                 .statusCode(200).extract()
                 .jsonPath().getList(".", ReservationTimeResponse.class);

--- a/src/test/java/roomescape/domain/reservation/controller/ReservationTimeControllerTest.java
+++ b/src/test/java/roomescape/domain/reservation/controller/ReservationTimeControllerTest.java
@@ -32,14 +32,14 @@ class ReservationTimeControllerTest {
     @Test
     void getReservationTimesTest() {
         RestAssured.given().log().all()
-                .cookie("token", createUserAccessToken())
-                .when().get("/times")
+                .cookie("token", createAdminToken())
+                .when().get("/admin/times")
                 .then().log().all()
                 .statusCode(200)
                 .body("size()", is(8));
     }
 
-    private String createUserAccessToken() {
-        return tokenProvider.createToken(3L, MemberRole.USER);
+    private String createAdminToken() {
+        return tokenProvider.createToken(3L, MemberRole.ADMIN);
     }
 }

--- a/src/test/java/roomescape/domain/reservation/repository/CustomReservationWaitingRepositoryImplTest.java
+++ b/src/test/java/roomescape/domain/reservation/repository/CustomReservationWaitingRepositoryImplTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import roomescape.domain.reservation.model.ReservationWaitingWithOrder;
-import roomescape.domain.reservation.repository.CustomReservationWaitingRepository;
 
 import java.util.List;
 
@@ -31,10 +30,10 @@ class CustomReservationWaitingRepositoryImplTest {
         // Then
         assertAll(
                 () -> assertThat(reservationWaitingWithOrders).hasSize(2),
-                () -> assertThat(firstReservationWaitingWithOrder.getReservationWaiting().getId()).isEqualTo(1L),
-                () -> assertThat(firstReservationWaitingWithOrder.getOrder()).isEqualTo(1),
-                () -> assertThat(secondReservationWaitingWithOrder.getReservationWaiting().getId()).isEqualTo(4L),
-                () -> assertThat(secondReservationWaitingWithOrder.getOrder()).isEqualTo(2)
+                () -> assertThat(firstReservationWaitingWithOrder.reservationWaiting().getId()).isEqualTo(1L),
+                () -> assertThat(firstReservationWaitingWithOrder.order()).isEqualTo(1),
+                () -> assertThat(secondReservationWaitingWithOrder.reservationWaiting().getId()).isEqualTo(4L),
+                () -> assertThat(secondReservationWaitingWithOrder.order()).isEqualTo(2)
         );
     }
 }

--- a/src/test/java/roomescape/domain/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/domain/reservation/repository/ReservationRepositoryTest.java
@@ -12,7 +12,6 @@ import roomescape.domain.reservation.model.ReservationDate;
 import roomescape.domain.reservation.model.ReservationStatus;
 import roomescape.domain.reservation.model.ReservationTime;
 import roomescape.domain.reservation.model.Theme;
-import roomescape.domain.reservation.repository.ReservationRepository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -62,17 +61,6 @@ class ReservationRepositoryTest {
                 () -> assertThat(savedReservation.getDate()).isEqualTo(reservation.getDate()),
                 () -> assertThat(savedReservation.getTime()).isEqualTo(reservation.getTime())
         );
-    }
-
-    @DisplayName("예약 정보를 삭제한다.")
-    @Test
-    void deleteByIdTest() {
-        // When
-        reservationRepository.deleteById(1L);
-
-        // Then
-        final long count = reservationRepository.count();
-        assertThat(count).isEqualTo(15);
     }
 
     @DisplayName("특정 날짜와 시간 아이디를 가진 예약이 존재하는지 조회한다.")

--- a/src/test/java/roomescape/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/domain/reservation/service/ReservationServiceTest.java
@@ -48,7 +48,7 @@ class ReservationServiceTest {
 
     @DisplayName("예약 정보를 저장한다.")
     @Test
-    void saveReservationTest() {
+    void saveReservationWithPaymentConfirmTest() {
         // Given
         final LocalDate date = LocalDate.now().plusDays(10);
         final SaveReservationRequest saveReservationRequest = new SaveReservationRequest(
@@ -62,7 +62,7 @@ class ReservationServiceTest {
         );
 
         // When
-        final ReservationDto reservation = reservationService.saveReservation(saveReservationRequest);
+        final ReservationDto reservation = reservationService.saveReservationWithPaymentConfirm(saveReservationRequest);
 
         // Then
         final List<ReservationDto> reservations = reservationService.getReservations();
@@ -77,7 +77,7 @@ class ReservationServiceTest {
 
     @DisplayName("저장하려는 예약 시간이 존재하지 않는다면 예외를 발생시킨다.")
     @Test
-    void throwExceptionWhenSaveReservationWithNotExistReservationTimeTest() {
+    void throwExceptionWhenSaveReservationWithNotExistReservationWithPaymentTimeTest() {
         // Given
         final SaveReservationRequest saveReservationRequest = new SaveReservationRequest(
                 LocalDate.now(),
@@ -90,37 +90,9 @@ class ReservationServiceTest {
         );
 
         // When & Then
-        assertThatThrownBy(() -> reservationService.saveReservation(saveReservationRequest))
+        assertThatThrownBy(() -> reservationService.saveReservationWithPaymentConfirm(saveReservationRequest))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("해당 id의 예약 시간이 존재하지 않습니다.");
-    }
-
-    @DisplayName("예약 정보를 삭제한다.")
-    @Test
-    void deleteReservationTest() {
-        // When
-        reservationService.deleteReservation(1L);
-
-        // When & Then
-        final List<ReservationDto> reservations = reservationService.getReservations();
-        assertThat(reservations).hasSize(15);
-    }
-
-    @DisplayName("예약 정보를 삭제하면 가장 우선 순위가 빠른 예약 대기가 예약으로 등록된다.")
-    @Test
-    void changeWaitingToReservationWhenDeleteReservationTest() {
-        // When
-        final ReservationWaiting reservationWaiting = reservationWaitingRepository.findById(1L).get();
-        reservationService.deleteReservation(13L);
-        final Reservation newReservation = reservationRepository.findById(17L).get();
-
-        // Then
-        assertAll(
-                () -> assertThat(reservationWaiting.getTheme().getId()).isEqualTo(newReservation.getTheme().getId()),
-                () -> assertThat(reservationWaiting.getMember().getId()).isEqualTo(newReservation.getMember().getId()),
-                () -> assertThat(reservationWaiting.getDate().getValue()).isEqualTo(newReservation.getDate().getValue()),
-                () -> assertThat(reservationWaiting.getTime().getStartAt()).isEqualTo(newReservation.getTime().getStartAt())
-        );
     }
 
     @DisplayName("현재 보다 이전 날짜/시간의 예약 정보를 저장하려고 하면 예외가 발생한다.")
@@ -138,7 +110,7 @@ class ReservationServiceTest {
         );
 
         // When & Then
-        assertThatThrownBy(() -> reservationService.saveReservation(saveReservationRequest))
+        assertThatThrownBy(() -> reservationService.saveReservationWithPaymentConfirm(saveReservationRequest))
                 .isInstanceOf(InvalidReserveInputException.class)
                 .hasMessage("현재 날짜보다 이전 날짜를 예약할 수 없습니다.");
     }
@@ -158,7 +130,7 @@ class ReservationServiceTest {
         );
 
         // When & Then
-        assertThatThrownBy(() -> reservationService.saveReservation(saveReservationRequest))
+        assertThatThrownBy(() -> reservationService.saveReservationWithPaymentConfirm(saveReservationRequest))
                 .isInstanceOf(InvalidReserveInputException.class)
                 .hasMessage("이미 해당 날짜/시간의 테마 예약이 있습니다.");
     }

--- a/src/test/java/roomescape/domain/reservation/service/ReservationTimeServiceTest.java
+++ b/src/test/java/roomescape/domain/reservation/service/ReservationTimeServiceTest.java
@@ -41,7 +41,7 @@ class ReservationTimeServiceTest {
     @Test
     void saveReservationTimeTest() {
         // Given
-        final LocalTime startAt = LocalTime.now().plusHours(1);
+        final LocalTime startAt = LocalTime.now().plusHours(0);
         final SaveReservationTimeRequest saveReservationTimeRequest = new SaveReservationTimeRequest(startAt);
 
         // When

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -127,3 +127,40 @@ VALUES (2, CAST(TIMESTAMPADD(DAY, 6, NOW()) AS DATE), 3, 8, CAST(TIMESTAMPADD(MI
  */
 INSERT INTO payment_credential(order_id, amount)
 VALUES ('test-order-id', 10000);
+
+/**
+  Payment History
+ */
+
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (1, 'test_order_id_1', 'gen_test_payment_key_1', 'test_order_name', 'DONE', 30000, '토스페이', NOW());
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (2, 'test_order_id_2', 'gen_test_payment_key_2', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (3, 'test_order_id_3', 'gen_test_payment_key_3', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (4, 'test_order_id_4', 'gen_test_payment_key_4', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (5, 'test_order_id_5', 'gen_test_payment_key_5', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (6, 'test_order_id_6', 'gen_test_payment_key_6', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (7, 'test_order_id_7', 'gen_test_payment_key_7', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (8, 'test_order_id_8', 'gen_test_payment_key_8', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (9, 'test_order_id_9', 'gen_test_payment_key_9', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (10, 'test_order_id_10', 'gen_test_payment_key_10', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (11, 'test_order_id_11', 'gen_test_payment_key_11', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (12, 'test_order_id_12', 'gen_test_payment_key_12', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (13, 'test_order_id_13', 'gen_test_payment_key_13', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (14, 'test_order_id_14', 'gen_test_payment_key_14', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (15, 'test_order_id_15', 'gen_test_payment_key_15', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (16, 'test_order_id_16', 'gen_test_payment_key_16', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -131,36 +131,35 @@ VALUES ('test-order-id', 10000);
 /**
   Payment History
  */
-
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (1, 'test_order_id_1', 'gen_test_payment_key_1', 'test_order_name', 'DONE', 30000, '토스페이', NOW());
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (2, 'test_order_id_2', 'gen_test_payment_key_2', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (3, 'test_order_id_3', 'gen_test_payment_key_3', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (4, 'test_order_id_4', 'gen_test_payment_key_4', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (5, 'test_order_id_5', 'gen_test_payment_key_5', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (6, 'test_order_id_6', 'gen_test_payment_key_6', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (7, 'test_order_id_7', 'gen_test_payment_key_7', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (8, 'test_order_id_8', 'gen_test_payment_key_8', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (9, 'test_order_id_9', 'gen_test_payment_key_9', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (10, 'test_order_id_10', 'gen_test_payment_key_10', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (11, 'test_order_id_11', 'gen_test_payment_key_11', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (12, 'test_order_id_12', 'gen_test_payment_key_12', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (13, 'test_order_id_13', 'gen_test_payment_key_13', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (14, 'test_order_id_14', 'gen_test_payment_key_14', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (15, 'test_order_id_15', 'gen_test_payment_key_15', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
-INSERT INTO payment_history(reservation_id, order_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
-VALUES (16, 'test_order_id_16', 'gen_test_payment_key_16', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (1, 'gen_test_payment_key_1', 'test_order_name', 'DONE', 30000, '토스페이', NOW());
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (2, 'gen_test_payment_key_2', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (3, 'gen_test_payment_key_3', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (4, 'gen_test_payment_key_4', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (5, 'gen_test_payment_key_5', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (6, 'gen_test_payment_key_6', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (7, 'gen_test_payment_key_7', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (8, 'gen_test_payment_key_8', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (9, 'gen_test_payment_key_9', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (10, 'gen_test_payment_key_10', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (11, 'gen_test_payment_key_11', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (12, 'gen_test_payment_key_12', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (13, 'gen_test_payment_key_13', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (14, 'gen_test_payment_key_14', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (15, 'gen_test_payment_key_15', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));
+INSERT INTO payment_history(reservation_id, payment_key, order_name, payment_status, total_amount, payment_provider, approved_at)
+VALUES (16, 'gen_test_payment_key_16', 'test_order_name', 'DONE', 30000, '토스페이', CAST(TIMESTAMPADD(DAY, 0, NOW()) AS DATETIME));


### PR DESCRIPTION
안녕하세요 수달! PR이 늦어져서 정말 죄송합니다..! 이것저것 욕심이 들어서 많이 시도하다... 꼬인게 많아서 우선 저번처럼 적당히 타협점을 찾아 요청 드립니다!! 부족한 부분은 계속 개선해나겠습니다! 이번 리뷰도 잘 부탁 드려요!!

이번 미션은 배포 & 문서화가 존재해 링크 남기겠습니다!
- 배포 주소 : [방탈출 예약 서비스](http://13.125.101.28:8080/)
- API 명세 주소 : [API 명세서 주소](https://succulent-bottle-ad0.notion.site/API-f692fa1c0cc94c2b8263f2c19aff3dfd?pvs=4)
- ERD 주소 : [ERD](https://www.erdcloud.com/d/vJN6cxhRZJAJsQXBk)

# 😢 더 개선할 부분
- [ ] 테스트 코드 보충 및 개선
- [ ] service 영역 분리
- [ ] 코드 정리
- [ ] API 명세에 실패 응답 내용 추가

# 👀 드리고 싶은 말씀
## 결제 & 예약의 경계
이번 미션에서 가장 어려웠던 부분은 `결제` 도메인과 `예약` 도메인의 분리가 가장 어려웠습니다. 두 도메인의 비즈니스 로직을 최대한 분리하고 싶었지만 요구사항 중 `예약`정보와 `결제`정보를 함께 요청하는 부분이 많아 서비스 분리가 잘 이뤄지지 않아 너무 아쉬웠습니다.

현재 복잡한 서비스 로직을 어떻게 하면 개선할 수 있을지 수달의 의견이 궁금합니다. 👀

## 왜 API 명세서를 노션으로 작성했는가?
처음에는 `Swagger` 혹은 `REST DOCS`같은 문서화 도구를 고려했습니다. 다만 아직 문서화 도구를 잘 다루지 못하고 시간안에 PR을 제출하지 못할거 같다는 생각이 들어 우선은 노션으로 명세를 작성하였습니다.