### PR TITLE
[2 - 4 단계 방탈출 결제 / 배포] 젠슨(이성우) 미션 제출합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/resources/application.yaml
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 src/main/resources/application.yaml
+deploy.sh
 
 ### STS ###
 .apt_generated

--- a/REVIEWER.md
+++ b/REVIEWER.md
@@ -1,3 +1,5 @@
+### swagger ui
+http://3.36.78.46:8080/swagger-ui/index.html
 
 #### 배포 스트립크는 누가 사용하는지 따로 요구사항이 주어지지 않아 제 local에서만 배포할 수 있도록 설정해놨습니다.
 ### deploy.sh

--- a/REVIEWER.md
+++ b/REVIEWER.md
@@ -1,0 +1,109 @@
+
+#### 배포 스트립크는 누가 사용하는지 따로 요구사항이 주어지지 않아 제 local에서만 배포할 수 있도록 설정해놨습니다.
+### deploy.sh
+```
+#!/bin/bash
+EC2_HOST="ubuntu@ec2-3-36-57-197.ap-northeast-2.compute.amazonaws.com"
+PEM_KEY_PATH="/Users/spqje/key-jenson.pem"
+TARGET_DIR="~/home/ubuntu/app"
+JAR_NAME="spring-roomescape-payment-0.0.1-SNAPSHOT.jar"
+TARGET_JAR_PATH="$TARGET_DIR/$JAR_NAME"
+
+./gradlew clean build -x test
+
+scp -i "$PEM_KEY_PATH" "build/libs/$JAR_NAME" "$EC2_HOST:$TARGET_JAR_PATH"
+
+ssh -i "$PEM_KEY_PATH" "$EC2_HOST" << EOF
+  cd ~/app
+  pkill -f "$JAR_NAME" || true
+  nohup java -jar "$JAR_NAME"
+EOF
+```
+
+
+#### yml 파일은 main, test 의 내용이 다릅니다.
+#### application.yml은 src/main/resources 경로에,
+#### application.test.yml은 src/test/resources 경로에 설정 부탁드립니다.
+
+
+### application.yml
+```
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:database
+    username: sa
+    password:
+
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:data.sql
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: true
+
+security:
+  jwt:
+    token:
+      secret-key: s8R$kQz3nZ!L5pT7c@J#xM9vB1&uD6hE
+      access:
+        expire-length: 600000 # 10 분
+
+scheduler:
+  request:
+    time: 60000 
+  valid:
+    period: 60s
+
+
+logging:
+  level:
+    root: info
+```
+
+### application.test.yml
+```
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:test.sql
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: true
+
+security:
+  jwt:
+    token:
+      secret-key: s8R$kQz3nZ!L5pT7c@J#xM9vB1&uD6hE
+      access:
+        expire-length: 600000 # 10 분
+
+scheduler:
+  request:
+    time: 600 
+  valid:
+    period: 1s
+
+```

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
-    implementation 'org.projectlombok:lombok:0.11.0'
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+    implementation 'org.projectlombok:lombok:0.11.0'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+EC2_HOST="ubuntu@ec2-3-36-57-197.ap-northeast-2.compute.amazonaws.com"
+PEM_KEY_PATH="/Users/spqje/key-jenson.pem"
+TARGET_DIR="~/home/ubuntu/app"
+JAR_NAME="spring-roomescape-payment-0.0.1-SNAPSHOT.jar"
+TARGET_JAR_PATH="$TARGET_DIR/$JAR_NAME"
+
+./gradlew clean build -x test
+
+scp -i "$PEM_KEY_PATH" "build/libs/$JAR_NAME" "$EC2_HOST:$TARGET_JAR_PATH"
+
+ssh -i "$PEM_KEY_PATH" "$EC2_HOST" << EOF
+  cd ~/app
+  pkill -f "$JAR_NAME" || true
+  nohup java -jar "$JAR_NAME"
+EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-EC2_HOST="ubuntu@ec2-3-36-57-197.ap-northeast-2.compute.amazonaws.com"
+EC2_HOST="ubuntu@ec2-43-201-62-219.ap-northeast-2.compute.amazonaws.com"
 PEM_KEY_PATH="/Users/spqje/key-jenson.pem"
-TARGET_DIR="~/home/ubuntu/app"
+TARGET_DIR="/home/ubuntu/app"
 JAR_NAME="spring-roomescape-payment-0.0.1-SNAPSHOT.jar"
 TARGET_JAR_PATH="$TARGET_DIR/$JAR_NAME"
 

--- a/src/main/java/roomescape/common/config/SchedulerConfig.java
+++ b/src/main/java/roomescape/common/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package roomescape.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+}

--- a/src/main/java/roomescape/common/config/SchedulerConfig.java
+++ b/src/main/java/roomescape/common/config/SchedulerConfig.java
@@ -2,6 +2,7 @@ package roomescape.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
 @Configuration
 @EnableScheduling
 public class SchedulerConfig {

--- a/src/main/java/roomescape/common/config/SchedulerConfig.java
+++ b/src/main/java/roomescape/common/config/SchedulerConfig.java
@@ -2,7 +2,6 @@ package roomescape.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
-
 @Configuration
 @EnableScheduling
 public class SchedulerConfig {

--- a/src/main/java/roomescape/common/config/SwaggerConfig.java
+++ b/src/main/java/roomescape/common/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package roomescape.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openApi() {
+        return new OpenAPI()
+            .addSecurityItem(new SecurityRequirement().addList("CookieAuth"))
+            .components(new Components()
+                .addSecuritySchemes("CookieAuth", createCookieSchema()))
+            .info(new Info().title("방탈출 예약 시스템"));
+    }
+
+    private SecurityScheme createCookieSchema() {
+        return new SecurityScheme()
+            .type(Type.APIKEY)
+            .in(SecurityScheme.In.COOKIE)
+            .name("token");
+    }
+}

--- a/src/main/java/roomescape/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import roomescape.common.exception.impl.ForbiddenException;
 import roomescape.common.exception.impl.NotFoundException;
 import roomescape.common.exception.impl.TossConfirmException;
 import roomescape.common.exception.impl.UnauthorizedException;
+import roomescape.payment.exception.TossErrorCode;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -29,6 +30,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handle(final TossConfirmException e) {
         log.error(
             "toss api exception : " + "code : " + e.getCode() + ", message :" + e.getMessage());
+
+        if (TossErrorCode.canSendTossMessage(e.getCode())) {
+            return new ResponseEntity<>(e.getMessage(), e.getStatus());
+        }
         return new ResponseEntity<>("서버 내부에 오류가 발생했습니다.", e.getStatus());
     }
 

--- a/src/main/java/roomescape/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/common/exception/GlobalExceptionHandler.java
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<String> handle(final BadRequestException e) {
         log.error(e.getMessage());
-        return new ResponseEntity<>("잘못된 요청입니다.", HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(NotFoundException.class)

--- a/src/main/java/roomescape/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/common/exception/GlobalExceptionHandler.java
@@ -7,10 +7,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 import roomescape.common.exception.impl.BadRequestException;
 import roomescape.common.exception.impl.ConflictException;
 import roomescape.common.exception.impl.ForbiddenException;
 import roomescape.common.exception.impl.NotFoundException;
+import roomescape.common.exception.impl.TokenExpiredException;
 import roomescape.common.exception.impl.TossConfirmException;
 import roomescape.common.exception.impl.UnauthorizedException;
 import roomescape.payment.exception.TossErrorCode;
@@ -26,6 +28,12 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>("서버 내부에 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<String> handle(final NoResourceFoundException e) {
+        log.warn("cannot found resource or page", e.getMessage());
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
     @ExceptionHandler(TossConfirmException.class)
     public ResponseEntity<String> handle(final TossConfirmException e) {
         log.error(
@@ -39,19 +47,19 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<String> handle(final BadRequestException e) {
-        log.error(e.getMessage());
+        log.warn(e.getMessage());
         return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<String> handle(final NotFoundException e) {
-        log.error(e.getMessage());
+        log.warn(e.getMessage());
         return new ResponseEntity<>("잘못된 요청입니다.", HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(ConflictException.class)
     public ResponseEntity<String> handle(final ConflictException e) {
-        log.error(e.getMessage());
+        log.warn(e.getMessage());
         return new ResponseEntity<>("잘못된 요청입니다.", HttpStatus.CONFLICT);
     }
 
@@ -61,15 +69,21 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>("잘못된 요청입니다.", HttpStatus.UNAUTHORIZED);
     }
 
+    @ExceptionHandler(TokenExpiredException.class)
+    public ResponseEntity<String> handle(final TokenExpiredException e) {
+        log.warn("토큰 만료: {}", e.getMessage());
+        return new ResponseEntity<>("잘못된 요청입니다.", HttpStatus.UNAUTHORIZED);
+    }
+
     @ExceptionHandler(ForbiddenException.class)
     public ResponseEntity<String> handle(final ForbiddenException e) {
-        log.error(e.getMessage());
+        log.warn(e.getMessage());
         return new ResponseEntity<>("잘못된 요청입니다.", HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleValidation(final MethodArgumentNotValidException e) {
-        log.error(e.getMessage());
+        log.warn(e.getMessage());
         return new ResponseEntity<>("잘못된 요청입니다.", HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/roomescape/common/exception/impl/TokenExpiredException.java
+++ b/src/main/java/roomescape/common/exception/impl/TokenExpiredException.java
@@ -1,0 +1,10 @@
+package roomescape.common.exception.impl;
+
+import roomescape.common.exception.RoomescapeException;
+
+public class TokenExpiredException extends RoomescapeException {
+
+    public TokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/common/log/HttpLogMessage.java
+++ b/src/main/java/roomescape/common/log/HttpLogMessage.java
@@ -1,0 +1,26 @@
+package roomescape.common.log;
+
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+public record HttpLogMessage(
+    String httpMethod,
+    String requestUri,
+    int httpStatus,
+    String clientIp,
+    String requestBody,
+    String responseBody
+) {
+
+    public static HttpLogMessage createInstance(ContentCachingRequestWrapper requestWrapper,
+        ContentCachingResponseWrapper responseWrapper) {
+        return new HttpLogMessage(
+            requestWrapper.getMethod(),
+            requestWrapper.getRequestURI(),
+            responseWrapper.getStatus(),
+            requestWrapper.getRemoteAddr(),
+            HttpLoggingUtils.getRequestBody(requestWrapper),
+            HttpLoggingUtils.getResponseBody(responseWrapper)
+        );
+    }
+}

--- a/src/main/java/roomescape/common/log/HttpLoggingUtils.java
+++ b/src/main/java/roomescape/common/log/HttpLoggingUtils.java
@@ -6,13 +6,13 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 
 public class HttpLoggingUtils {
 
-    private HttpLoggingUtils() {}
+    private HttpLoggingUtils() {
+    }
 
     public static String getRequestBody(ContentCachingRequestWrapper request) {
         try {
             return new String(request.getContentAsByteArray(), StandardCharsets.UTF_8);
         } catch (Exception e) {
-            // 예외 처리
             return "Failed to read request body";
         }
     }

--- a/src/main/java/roomescape/common/log/HttpLoggingUtils.java
+++ b/src/main/java/roomescape/common/log/HttpLoggingUtils.java
@@ -1,0 +1,27 @@
+package roomescape.common.log;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+public class HttpLoggingUtils {
+
+    private HttpLoggingUtils() {}
+
+    public static String getRequestBody(ContentCachingRequestWrapper request) {
+        try {
+            return new String(request.getContentAsByteArray(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            // 예외 처리
+            return "Failed to read request body";
+        }
+    }
+
+    public static String getResponseBody(ContentCachingResponseWrapper response) {
+        try {
+            return new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return "Failed to read response body";
+        }
+    }
+}

--- a/src/main/java/roomescape/common/log/RequestResponseLoggingFilter.java
+++ b/src/main/java/roomescape/common/log/RequestResponseLoggingFilter.java
@@ -1,0 +1,69 @@
+package roomescape.common.log;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestResponseLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain chain) throws ServletException, IOException {
+        ContentCachingRequestWrapper cacheRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper cacheResponse = new ContentCachingResponseWrapper(response);
+
+        chain.doFilter(cacheRequest, cacheResponse);
+        if (isNotLoggingUri(cacheRequest.getRequestURI())) {
+            cacheResponse.copyBodyToResponse();
+            return;
+        }
+        generateLogging(cacheRequest, cacheResponse);
+    }
+
+    private void generateLogging(ContentCachingRequestWrapper cacheRequest,
+        ContentCachingResponseWrapper cacheResponse) throws IOException {
+        HttpLogMessage logMessage = HttpLogMessage.createInstance(cacheRequest, cacheResponse);
+        log.info(logMessage.toString());
+        cacheResponse.copyBodyToResponse();
+    }
+
+    /**
+     * 정적 페이지입니다.
+     */
+    private static final List<String> EXCLUDE_URI = Arrays.asList(
+        "/",
+        "/admin/reservation",
+        "/admin/time",
+        "/admin/theme",
+        "/admin/waiting",
+        "/reservation",
+        "/reservation-mine",
+        "/payment",
+        "/login",
+        "/signup"
+    );
+
+
+    private boolean isNotLoggingUri(String uri)  {
+        return EXCLUDE_URI.contains(uri) || isStaticResource(uri);
+    }
+
+    private boolean isStaticResource(String uri) {
+        return uri.endsWith(".css") || uri.endsWith(".js") ||
+            uri.endsWith(".html") || uri.startsWith("/image");
+    }
+}

--- a/src/main/java/roomescape/common/log/RequestResponseLoggingFilter.java
+++ b/src/main/java/roomescape/common/log/RequestResponseLoggingFilter.java
@@ -7,7 +7,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -26,19 +28,23 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
         ContentCachingRequestWrapper cacheRequest = new ContentCachingRequestWrapper(request);
         ContentCachingResponseWrapper cacheResponse = new ContentCachingResponseWrapper(response);
 
+        String requestId = UUID.randomUUID().toString().substring(0, 8);
+        MDC.put("request_id", requestId);
         chain.doFilter(cacheRequest, cacheResponse);
         if (isNotLoggingUri(cacheRequest.getRequestURI())) {
+            MDC.remove(requestId);
             cacheResponse.copyBodyToResponse();
             return;
         }
-        generateLogging(cacheRequest, cacheResponse);
+        generateLogging(cacheRequest, cacheResponse, requestId);
     }
 
     private void generateLogging(ContentCachingRequestWrapper cacheRequest,
-        ContentCachingResponseWrapper cacheResponse) throws IOException {
+        ContentCachingResponseWrapper cacheResponse, String requestId) throws IOException {
         HttpLogMessage logMessage = HttpLogMessage.createInstance(cacheRequest, cacheResponse);
         log.info(logMessage.toString());
         cacheResponse.copyBodyToResponse();
+        MDC.remove(requestId);
     }
 
     /**

--- a/src/main/java/roomescape/common/log/RequestResponseLoggingFilter.java
+++ b/src/main/java/roomescape/common/log/RequestResponseLoggingFilter.java
@@ -22,6 +22,22 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class RequestResponseLoggingFilter extends OncePerRequestFilter {
 
+    /**
+     * 정적 페이지입니다.
+     */
+    private static final List<String> EXCLUDE_URI = Arrays.asList(
+        "/",
+        "/admin/reservation",
+        "/admin/time",
+        "/admin/theme",
+        "/admin/waiting",
+        "/reservation",
+        "/reservation-mine",
+        "/payment",
+        "/login",
+        "/signup"
+    );
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain chain) throws ServletException, IOException {
@@ -47,24 +63,7 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
         MDC.remove(requestId);
     }
 
-    /**
-     * 정적 페이지입니다.
-     */
-    private static final List<String> EXCLUDE_URI = Arrays.asList(
-        "/",
-        "/admin/reservation",
-        "/admin/time",
-        "/admin/theme",
-        "/admin/waiting",
-        "/reservation",
-        "/reservation-mine",
-        "/payment",
-        "/login",
-        "/signup"
-    );
-
-
-    private boolean isNotLoggingUri(String uri)  {
+    private boolean isNotLoggingUri(String uri) {
         return EXCLUDE_URI.contains(uri) || isStaticResource(uri);
     }
 

--- a/src/main/java/roomescape/common/ui/UserPageController.java
+++ b/src/main/java/roomescape/common/ui/UserPageController.java
@@ -15,4 +15,9 @@ public class UserPageController {
     public String myReservationDashBoard() {
         return "reservation-mine";
     }
+
+    @GetMapping("/payment")
+    public String paymentPage() {
+        return "payment";
+    }
 }

--- a/src/main/java/roomescape/login/application/JwtHandler.java
+++ b/src/main/java/roomescape/login/application/JwtHandler.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import roomescape.common.exception.impl.TokenExpiredException;
 import roomescape.common.exception.impl.UnauthorizedException;
 import roomescape.login.application.dto.Token;
 import roomescape.member.domain.Member;
@@ -63,7 +64,7 @@ public class JwtHandler {
                 .parseClaimsJws(token)
                 .getBody();
         } catch (final ExpiredJwtException e) {
-            throw new UnauthorizedException("로그인 정보가 만료되었습니다.");
+            throw new TokenExpiredException("로그인 정보가 만료되었습니다.");
         } catch (final UnsupportedJwtException | MalformedJwtException | SignatureException e) {
             throw new UnauthorizedException("로그인 정보가 유효하지 않습니다.");
         }

--- a/src/main/java/roomescape/login/application/LoginService.java
+++ b/src/main/java/roomescape/login/application/LoginService.java
@@ -40,7 +40,6 @@ public class LoginService {
     public LoginCheckResponse checkLogin(final LoginCheckRequest request) {
         final Member member = memberRepository.findById(request.id())
             .orElseThrow(() -> new NotFoundException("회원 정보가 존재하지 않습니다."));
-        log.info("member login: ", member.getId());
         return LoginCheckResponse.from(member);
     }
 

--- a/src/main/java/roomescape/login/application/LoginService.java
+++ b/src/main/java/roomescape/login/application/LoginService.java
@@ -1,5 +1,6 @@
 package roomescape.login.application;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.common.exception.impl.BadRequestException;
@@ -14,6 +15,7 @@ import roomescape.member.domain.Member;
 import roomescape.member.domain.Password;
 import roomescape.member.domain.repository.MemberRepository;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 public class LoginService {
@@ -38,7 +40,7 @@ public class LoginService {
     public LoginCheckResponse checkLogin(final LoginCheckRequest request) {
         final Member member = memberRepository.findById(request.id())
             .orElseThrow(() -> new NotFoundException("회원 정보가 존재하지 않습니다."));
-
+        log.info("member login: ", member.getId());
         return LoginCheckResponse.from(member);
     }
 

--- a/src/main/java/roomescape/payment/application/PaymentService.java
+++ b/src/main/java/roomescape/payment/application/PaymentService.java
@@ -2,9 +2,6 @@ package roomescape.payment.application;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import roomescape.common.exception.impl.NotFoundException;
-import roomescape.member.domain.Member;
-import roomescape.member.domain.repository.MemberRepository;
 import roomescape.payment.application.dto.PaymentRequest;
 import roomescape.payment.application.dto.TossConfirmRequest;
 import roomescape.payment.application.dto.TossConfirmResponse;
@@ -12,61 +9,29 @@ import roomescape.payment.domain.Payment;
 import roomescape.payment.domain.PaymentGateway;
 import roomescape.payment.domain.PaymentInfo;
 import roomescape.payment.domain.repository.PaymentRepository;
-import roomescape.reservation.domain.ReservationTime;
-import roomescape.reservation.domain.repository.ReservationTimeRepository;
-import roomescape.theme.domain.Theme;
-import roomescape.theme.domain.repository.ThemeRepository;
 
 @Service
 @Transactional(readOnly = true)
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
-    private final ReservationTimeRepository reservationTimeRepository;
-    private final ThemeRepository themeRepository;
-    private final MemberRepository memberRepository;
     private final TossPaymentGatewayClient tossPaymentGatewayClient;
 
-    public PaymentService(final PaymentRepository paymentRepository,
-        final ReservationTimeRepository reservationTimeRepository,
-        final ThemeRepository themeRepository,
-        final MemberRepository memberRepository,
-        final TossPaymentGatewayClient tossPaymentGatewayClient) {
+    public PaymentService(
+        final PaymentRepository paymentRepository,
+        final TossPaymentGatewayClient tossPaymentGatewayClient
+    ) {
         this.paymentRepository = paymentRepository;
-        this.reservationTimeRepository = reservationTimeRepository;
-        this.themeRepository = themeRepository;
-        this.memberRepository = memberRepository;
         this.tossPaymentGatewayClient = tossPaymentGatewayClient;
     }
 
     @Transactional
-    public Payment addPayment(
-        final PaymentRequest request,
-        final Long memberId
-    ) {
+    public Payment addPayment(final PaymentRequest request) {
         TossConfirmResponse response = tossPaymentGatewayClient.processPaymentConfirm(
             new TossConfirmRequest(request.paymentKey(), request.orderId(), request.amount()));
-        ReservationTime reservationTime = getReservationTime(request.timeId());
-        Member member = getMember(memberId);
-        Theme theme = getTheme(request.themeId());
-        Payment payment = new Payment(member, reservationTime, theme, request.date(),
+        Payment payment = new Payment(request.reservation(),
             new PaymentInfo(response.paymentKey(), response.orderId(), response.easyPay().amount()),
             PaymentGateway.TOSS_PAYMENTS);
         return paymentRepository.save(payment);
-    }
-
-    private ReservationTime getReservationTime(final Long timeId) {
-        return reservationTimeRepository.findById(timeId)
-            .orElseThrow(() -> new NotFoundException("선택한 예약 시간이 존재하지 않습니다."));
-    }
-
-    private Member getMember(final Long memberId) {
-        return memberRepository.findById(memberId)
-            .orElseThrow(() -> new NotFoundException("선택한 멤버가 존재하지 않습니다."));
-    }
-
-    private Theme getTheme(final Long themeId) {
-        return themeRepository.findById(themeId)
-            .orElseThrow(() -> new NotFoundException("선택한 테마가 존재하지 않습니다."));
     }
 }

--- a/src/main/java/roomescape/payment/application/PaymentService.java
+++ b/src/main/java/roomescape/payment/application/PaymentService.java
@@ -2,13 +2,17 @@ package roomescape.payment.application;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.common.exception.impl.NotFoundException;
 import roomescape.payment.application.dto.PaymentRequest;
+import roomescape.payment.application.dto.PaymentResponse;
 import roomescape.payment.application.dto.TossConfirmRequest;
 import roomescape.payment.application.dto.TossConfirmResponse;
 import roomescape.payment.domain.Payment;
 import roomescape.payment.domain.PaymentGateway;
 import roomescape.payment.domain.PaymentInfo;
 import roomescape.payment.domain.repository.PaymentRepository;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.repository.ReservationRepository;
 
 @Service
 @Transactional(readOnly = true)
@@ -16,22 +20,33 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final TossPaymentGatewayClient tossPaymentGatewayClient;
+    private final ReservationRepository reservationRepository;
 
     public PaymentService(
         final PaymentRepository paymentRepository,
-        final TossPaymentGatewayClient tossPaymentGatewayClient
+        final TossPaymentGatewayClient tossPaymentGatewayClient,
+        final ReservationRepository reservationRepository
     ) {
         this.paymentRepository = paymentRepository;
         this.tossPaymentGatewayClient = tossPaymentGatewayClient;
+        this.reservationRepository = reservationRepository;
     }
 
     @Transactional
-    public Payment addPayment(final PaymentRequest request) {
+    public PaymentResponse addPayment(final PaymentRequest request) {
         TossConfirmResponse response = tossPaymentGatewayClient.processPaymentConfirm(
             new TossConfirmRequest(request.paymentKey(), request.orderId(), request.amount()));
-        Payment payment = new Payment(request.reservation(),
+        Reservation reservation = getReservation(request.reservationId());
+        Payment payment = new Payment(
+            reservation,
             new PaymentInfo(response.paymentKey(), response.orderId(), response.easyPay().amount()),
             PaymentGateway.TOSS_PAYMENTS);
-        return paymentRepository.save(payment);
+        Payment saved = paymentRepository.save(payment);
+        return PaymentResponse.from(saved);
+    }
+
+    private Reservation getReservation(final Long reservationId) {
+        return reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new NotFoundException("찾으려는 예약이 존재하지 않습니다."));
     }
 }

--- a/src/main/java/roomescape/payment/application/PaymentService.java
+++ b/src/main/java/roomescape/payment/application/PaymentService.java
@@ -1,5 +1,7 @@
 package roomescape.payment.application;
 
+import static roomescape.reservation.domain.PaymentStatus.SUCCESS;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.common.exception.impl.NotFoundException;
@@ -42,6 +44,7 @@ public class PaymentService {
             new PaymentInfo(response.paymentKey(), response.orderId(), response.easyPay().amount()),
             PaymentGateway.TOSS_PAYMENTS);
         Payment saved = paymentRepository.save(payment);
+        reservation.changePaymentStatus(SUCCESS);
         return PaymentResponse.from(saved);
     }
 

--- a/src/main/java/roomescape/payment/application/dto/PaymentRequest.java
+++ b/src/main/java/roomescape/payment/application/dto/PaymentRequest.java
@@ -1,11 +1,9 @@
 package roomescape.payment.application.dto;
 
-import java.time.LocalDate;
+import roomescape.reservation.domain.Reservation;
 
 public record PaymentRequest(
-    LocalDate date,
-    Long timeId,
-    Long themeId,
+    Reservation reservation,
     String paymentKey,
     String orderId,
     Long amount

--- a/src/main/java/roomescape/payment/application/dto/PaymentRequest.java
+++ b/src/main/java/roomescape/payment/application/dto/PaymentRequest.java
@@ -1,9 +1,7 @@
 package roomescape.payment.application.dto;
 
-import roomescape.reservation.domain.Reservation;
-
 public record PaymentRequest(
-    Reservation reservation,
+    Long reservationId,
     String paymentKey,
     String orderId,
     Long amount

--- a/src/main/java/roomescape/payment/application/dto/PaymentResponse.java
+++ b/src/main/java/roomescape/payment/application/dto/PaymentResponse.java
@@ -1,0 +1,10 @@
+package roomescape.payment.application.dto;
+
+import roomescape.payment.domain.Payment;
+
+public record PaymentResponse(Long paymentId) {
+
+    public static PaymentResponse from(Payment payment) {
+        return new PaymentResponse(payment.getId());
+    }
+}

--- a/src/main/java/roomescape/payment/domain/Payment.java
+++ b/src/main/java/roomescape/payment/domain/Payment.java
@@ -8,12 +8,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import java.time.LocalDate;
+import jakarta.persistence.OneToOne;
 import java.util.Objects;
-import roomescape.member.domain.Member;
-import roomescape.reservation.domain.ReservationTime;
-import roomescape.theme.domain.Theme;
+import roomescape.reservation.domain.Reservation;
 
 @Entity
 public class Payment {
@@ -22,16 +19,8 @@ public class Payment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    private ReservationTime reservationTime;
-
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    private Theme theme;
-
-    private LocalDate date;
+    @OneToOne(fetch = FetchType.LAZY)
+    private Reservation reservation;
 
     @Embedded
     private PaymentInfo paymentInfo;
@@ -42,22 +31,17 @@ public class Payment {
     protected Payment() {
     }
 
-    public Payment(final Long id, final Member member, final ReservationTime reservationTime,
-        final Theme theme, final LocalDate date, final PaymentInfo paymentInfo,
+    public Payment(final Long id, final Reservation reservation, final PaymentInfo paymentInfo,
         final PaymentGateway paymentGateway) {
         this.id = id;
-        this.member = member;
-        this.reservationTime = reservationTime;
-        this.theme = theme;
-        this.date = date;
+        this.reservation = reservation;
         this.paymentInfo = paymentInfo;
         this.paymentGateway = paymentGateway;
     }
 
-    public Payment(final Member member, final ReservationTime reservationTime,
-        final Theme theme, final LocalDate date, final PaymentInfo paymentInfo,
+    public Payment(final Reservation reservation, final PaymentInfo paymentInfo,
         final PaymentGateway paymentGateway) {
-        this(null, member, reservationTime, theme, date, paymentInfo, paymentGateway);
+        this(null, reservation, paymentInfo, paymentGateway);
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/payment/domain/Payment.java
+++ b/src/main/java/roomescape/payment/domain/Payment.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.util.Objects;
 import roomescape.reservation.domain.Reservation;
@@ -19,6 +20,7 @@ public class Payment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @JoinColumn(name = "reservation_id")
     @OneToOne(fetch = FetchType.LAZY)
     private Reservation reservation;
 

--- a/src/main/java/roomescape/payment/exception/TossErrorCode.java
+++ b/src/main/java/roomescape/payment/exception/TossErrorCode.java
@@ -1,0 +1,40 @@
+package roomescape.payment.exception;
+
+import java.util.Arrays;
+
+/**
+ * 유저에게 에러 정보를 전달하면 안 되는 ErrorCode 모음입니다.
+ */
+public enum TossErrorCode {
+
+    INVALID_API_KEY,
+    INVALID_REQUEST,
+    NOT_FOUND_TERMINAL_ID,
+    INVALID_AUTHORIZE_AUTH,
+    INVALID_CARD_LOST_OR_STOLEN,
+    UNAPPROVED_ORDER_ID,
+    UNAUTHORIZED_KEY,
+    REJECT_CARD_COMPANY,
+    FORBIDDEN_REQUEST,
+    INCORRECT_BASIC_AUTH_FORMAT,
+    FDS_ERROR,
+    FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING,
+    FAILED_INTERNAL_SYSTEM_PROCESSING,
+    UNKNOWN_PAYMENT_ERROR,
+    FORBIDDEN_CONSECUTIVE_REQUEST,
+    NOT_FOUND,
+    NOT_FOUND_PAYMENT,
+    NOT_MATCHES_REFUNDABLE_AMOUNT,
+    PROVIDER_ERROR,
+    NOT_CANCELABLE_AMOUNT,
+    FAILED_METHOD_HANDLING_CANCEL,
+    COMMON_ERROR,
+    INVALID_ORDER_ID,
+    DUPLICATED_ORDER_ID,
+    INVALID_REQUIRED_PARAM;
+
+    public static boolean canSendTossMessage(String code) {
+        return Arrays.stream(TossErrorCode.values())
+            .noneMatch(e -> e.name().equals(code));
+    }
+}

--- a/src/main/java/roomescape/payment/ui/PaymentController.java
+++ b/src/main/java/roomescape/payment/ui/PaymentController.java
@@ -1,0 +1,26 @@
+package roomescape.payment.ui;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import roomescape.payment.application.PaymentService;
+import roomescape.payment.application.dto.PaymentRequest;
+import roomescape.payment.application.dto.PaymentResponse;
+
+@RestController
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    public PaymentController(PaymentService paymentService) {
+        this.paymentService = paymentService;
+    }
+
+    @PostMapping("/payment")
+    public ResponseEntity<PaymentResponse> add(@RequestBody PaymentRequest paymentRequest) {
+        PaymentResponse paymentResponse = paymentService.addPayment(paymentRequest);
+        return new ResponseEntity<>(paymentResponse, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/roomescape/reservation/application/ReservationScheduler.java
+++ b/src/main/java/roomescape/reservation/application/ReservationScheduler.java
@@ -1,6 +1,5 @@
 package roomescape.reservation.application;
 
-import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,7 +27,7 @@ public class ReservationScheduler {
     public void checkReservationPaymentExpiredTime() {
         LocalDateTime findTime = LocalDateTime.now().minus(validReservationTimePeriod);
         List<Reservation> reservations = reservationService.findByCreateTimeAndPaymentStatus(
-            Timestamp.valueOf(findTime), PaymentStatus.PENDING);
+            findTime, PaymentStatus.PENDING);
         for (Reservation reservation : reservations) {
             reservationService.deleteById(reservation.getId());
         }

--- a/src/main/java/roomescape/reservation/application/ReservationScheduler.java
+++ b/src/main/java/roomescape/reservation/application/ReservationScheduler.java
@@ -1,8 +1,10 @@
 package roomescape.reservation.application;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import roomescape.reservation.domain.PaymentStatus;
@@ -11,18 +13,20 @@ import roomescape.reservation.domain.Reservation;
 @Component
 public class ReservationScheduler {
 
-    private static final int REQUEST_TIME = 60_000;
-    private static final int VALID_RESERVATION_TIME_PERIOD = 15;
-
     private final ReservationService reservationService;
+    private final Duration validReservationTimePeriod;
 
-    public ReservationScheduler(ReservationService reservationService) {
+    public ReservationScheduler(
+        ReservationService reservationService,
+        @Value("${scheduler.valid.period}") Duration validReservationTimePeriod
+    ) {
         this.reservationService = reservationService;
+        this.validReservationTimePeriod = validReservationTimePeriod;
     }
 
-    @Scheduled(fixedRate = REQUEST_TIME)
+    @Scheduled(fixedRateString = "${scheduler.request.time}")
     public void checkReservationPaymentExpiredTime() {
-        LocalDateTime findTime = LocalDateTime.now().minusMinutes(VALID_RESERVATION_TIME_PERIOD);
+        LocalDateTime findTime = LocalDateTime.now().minus(validReservationTimePeriod);
         List<Reservation> reservations = reservationService.findByCreateTimeAndPaymentStatus(
             Timestamp.valueOf(findTime), PaymentStatus.PENDING);
         for (Reservation reservation : reservations) {

--- a/src/main/java/roomescape/reservation/application/ReservationScheduler.java
+++ b/src/main/java/roomescape/reservation/application/ReservationScheduler.java
@@ -2,6 +2,8 @@ package roomescape.reservation.application;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -25,7 +27,8 @@ public class ReservationScheduler {
 
     @Scheduled(fixedRateString = "${scheduler.request.time}")
     public void checkReservationPaymentExpiredTime() {
-        LocalDateTime findTime = LocalDateTime.now().minus(validReservationTimePeriod);
+        LocalDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+        LocalDateTime findTime = now.minus(validReservationTimePeriod);
         List<Reservation> reservations = reservationService.findByCreateTimeAndPaymentStatus(
             findTime, PaymentStatus.PENDING);
         for (Reservation reservation : reservations) {

--- a/src/main/java/roomescape/reservation/application/ReservationScheduler.java
+++ b/src/main/java/roomescape/reservation/application/ReservationScheduler.java
@@ -1,0 +1,32 @@
+package roomescape.reservation.application;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import roomescape.reservation.domain.PaymentStatus;
+import roomescape.reservation.domain.Reservation;
+
+@Component
+public class ReservationScheduler {
+
+    private static final int REQUEST_TIME = 60_000;
+    private static final int VALID_RESERVATION_TIME_PERIOD = 15;
+
+    private final ReservationService reservationService;
+
+    public ReservationScheduler(ReservationService reservationService) {
+        this.reservationService = reservationService;
+    }
+
+    @Scheduled(fixedRate = REQUEST_TIME)
+    public void checkReservationPaymentExpiredTime() {
+        LocalDateTime findTime = LocalDateTime.now().minusMinutes(VALID_RESERVATION_TIME_PERIOD);
+        List<Reservation> reservations = reservationService.findByCreateTimeAndPaymentStatus(
+            Timestamp.valueOf(findTime), PaymentStatus.PENDING);
+        for (Reservation reservation : reservations) {
+            reservationService.deleteById(reservation.getId());
+        }
+    }
+}

--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -2,7 +2,6 @@ package roomescape.reservation.application;
 
 import static roomescape.reservation.domain.PaymentStatus.PENDING;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -62,7 +61,7 @@ public class ReservationService {
             .toList();
     }
 
-    public List<Reservation> findByCreateTimeAndPaymentStatus(Timestamp createdAtBefore, PaymentStatus paymentStatus) {
+    public List<Reservation> findByCreateTimeAndPaymentStatus(LocalDateTime createdAtBefore, PaymentStatus paymentStatus) {
         return reservationRepository.findByCreatedAtBeforeAndPaymentStatus(createdAtBefore, paymentStatus);
     }
 

--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -61,8 +61,10 @@ public class ReservationService {
             .toList();
     }
 
-    public List<Reservation> findByCreateTimeAndPaymentStatus(LocalDateTime createdAtBefore, PaymentStatus paymentStatus) {
-        return reservationRepository.findByCreatedAtBeforeAndPaymentStatus(createdAtBefore, paymentStatus);
+    public List<Reservation> findByCreateTimeAndPaymentStatus(LocalDateTime createdAtBefore,
+        PaymentStatus paymentStatus) {
+        return reservationRepository.findByCreatedAtBeforeAndPaymentStatus(createdAtBefore,
+            paymentStatus);
     }
 
     @Transactional
@@ -97,7 +99,8 @@ public class ReservationService {
         validateIsBooked(sameTimeReservations, reservationTime, theme);
         validatePastDateTime(date, reservationTime.getStartAt());
 
-        final Reservation reservation = new Reservation(date, reservationTime, theme, member, PENDING);
+        final Reservation reservation = new Reservation(date, reservationTime, theme, member,
+            PENDING);
         return reservationRepository.save(reservation);
     }
 

--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -1,5 +1,7 @@
 package roomescape.reservation.application;
 
+import static roomescape.reservation.domain.ReservationStatus.PENDING;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -88,7 +90,7 @@ public class ReservationService {
         validateIsBooked(sameTimeReservations, reservationTime, theme);
         validatePastDateTime(date, reservationTime.getStartAt());
 
-        final Reservation reservation = new Reservation(date, reservationTime, theme, member);
+        final Reservation reservation = new Reservation(date, reservationTime, theme, member, PENDING);
         return reservationRepository.save(reservation);
     }
 

--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -15,10 +15,12 @@ import roomescape.common.exception.impl.ConflictException;
 import roomescape.common.exception.impl.NotFoundException;
 import roomescape.member.domain.Member;
 import roomescape.member.domain.repository.MemberRepository;
+import roomescape.payment.domain.Payment;
 import roomescape.reservation.application.dto.AdminReservationRequest;
 import roomescape.reservation.application.dto.AvailableReservationTimeResponse;
 import roomescape.reservation.application.dto.MemberReservationRequest;
 import roomescape.reservation.application.dto.MyReservation;
+import roomescape.reservation.application.dto.MyReservationAndPaymentInfo;
 import roomescape.reservation.application.dto.ReservationResponse;
 import roomescape.reservation.domain.PaymentStatus;
 import roomescape.reservation.domain.Reservation;
@@ -164,10 +166,17 @@ public class ReservationService {
             .toList();
     }
 
-    public List<MyReservation> findByMemberId(final Long memberId) {
+    public List<MyReservationAndPaymentInfo> findByMemberId(final Long memberId) {
         final List<Reservation> reservations = reservationRepository.findByMemberId(memberId);
         return reservations.stream()
-            .map(MyReservation::from)
+            .map(reservation -> {
+                MyReservation myReservation = MyReservation.from(reservation);
+                Payment payment = reservation.getPayment();
+                if (payment == null) {
+                    return MyReservationAndPaymentInfo.from(myReservation, null);
+                }
+                return MyReservationAndPaymentInfo.from(myReservation, payment.getPaymentInfo());
+            })
             .toList();
     }
 

--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -12,8 +12,6 @@ import roomescape.common.exception.impl.ConflictException;
 import roomescape.common.exception.impl.NotFoundException;
 import roomescape.member.domain.Member;
 import roomescape.member.domain.repository.MemberRepository;
-import roomescape.payment.application.PaymentService;
-import roomescape.payment.application.dto.PaymentRequest;
 import roomescape.reservation.application.dto.AdminReservationRequest;
 import roomescape.reservation.application.dto.AvailableReservationTimeResponse;
 import roomescape.reservation.application.dto.MemberReservationRequest;
@@ -36,21 +34,19 @@ public class ReservationService {
     private final ThemeRepository themeRepository;
     private final MemberRepository memberRepository;
     private final WaitingRepository waitingRepository;
-    private final PaymentService paymentService;
 
     public ReservationService(
         final ReservationRepository reservationRepository,
         final ReservationTimeRepository reservationTimeRepository,
         final ThemeRepository themeRepository,
         final MemberRepository memberRepository,
-        final WaitingRepository waitingRepository,
-        final PaymentService paymentService) {
+        final WaitingRepository waitingRepository
+    ) {
         this.reservationRepository = reservationRepository;
         this.reservationTimeRepository = reservationTimeRepository;
         this.themeRepository = themeRepository;
         this.memberRepository = memberRepository;
         this.waitingRepository = waitingRepository;
-        this.paymentService = paymentService;
     }
 
     public List<ReservationResponse> findAll() {
@@ -61,18 +57,57 @@ public class ReservationService {
     }
 
     @Transactional
-    public ReservationResponse addMemberReservation(final MemberReservationRequest request,
-        final Long memberId) {
-        paymentService.addPayment(
-            new PaymentRequest(request.date(), request.timeId(), request.themeId(),
-                request.paymentKey(), request.orderId(), request.amount()), memberId);
-        return addReservation(request.timeId(), request.themeId(), memberId, request.date());
+    public ReservationResponse addMemberReservation(
+        final MemberReservationRequest request, final Long memberId) {
+        Reservation reservation = addReservation(
+            request.timeId(), request.themeId(), memberId, request.date());
+        return ReservationResponse.of(reservation);
     }
 
     @Transactional
     public ReservationResponse addAdminReservation(final AdminReservationRequest request) {
-        return addReservation(request.timeId(), request.themeId(), request.memberId(),
+        Reservation reservation = addReservation(
+            request.timeId(),
+            request.themeId(),
+            request.memberId(),
             request.date());
+        return ReservationResponse.of(reservation);
+    }
+
+    private Reservation addReservation(final Long timeId, final Long themeId,
+        final Long memberId,
+        final LocalDate date) {
+        final ReservationTime reservationTime = getReservationTime(timeId);
+        final Theme theme = getTheme(themeId);
+        final Member member = getMember(memberId);
+
+        final List<Reservation> sameTimeReservations = reservationRepository.findByDateAndThemeId(
+            date,
+            themeId);
+
+        validateIsBooked(sameTimeReservations, reservationTime, theme);
+        validatePastDateTime(date, reservationTime.getStartAt());
+
+        final Reservation reservation = new Reservation(date, reservationTime, theme, member);
+        return reservationRepository.save(reservation);
+    }
+
+    private void validateIsBooked(final List<Reservation> sameTimeReservations,
+        final ReservationTime reservationTime,
+        final Theme theme) {
+        final boolean isBooked = sameTimeReservations.stream()
+            .anyMatch(reservation -> reservation.hasConflictWith(reservationTime, theme));
+        if (isBooked) {
+            throw new ConflictException("해당 테마 이용시간이 겹칩니다.");
+        }
+    }
+
+    private void validatePastDateTime(final LocalDate date, final LocalTime time) {
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDateTime reservationDateTime = LocalDateTime.of(date, time);
+        if (reservationDateTime.isBefore(now)) {
+            throw new BadRequestException("현재보다 과거의 날짜로 예약 할 수 없습니다.");
+        }
     }
 
     @Transactional
@@ -126,43 +161,6 @@ public class ReservationService {
         return reservations.stream()
             .map(MyReservation::from)
             .toList();
-    }
-
-    private ReservationResponse addReservation(final Long timeId, final Long themeId,
-        final Long memberId,
-        final LocalDate date) {
-        final ReservationTime reservationTime = getReservationTime(timeId);
-        final Theme theme = getTheme(themeId);
-        final Member member = getMember(memberId);
-
-        final List<Reservation> sameTimeReservations = reservationRepository.findByDateAndThemeId(
-            date,
-            themeId);
-
-        validateIsBooked(sameTimeReservations, reservationTime, theme);
-        validatePastDateTime(date, reservationTime.getStartAt());
-
-        final Reservation reservation = new Reservation(date, reservationTime, theme, member);
-        final Reservation saved = reservationRepository.save(reservation);
-        return ReservationResponse.of(saved);
-    }
-
-    private void validateIsBooked(final List<Reservation> sameTimeReservations,
-        final ReservationTime reservationTime,
-        final Theme theme) {
-        final boolean isBooked = sameTimeReservations.stream()
-            .anyMatch(reservation -> reservation.hasConflictWith(reservationTime, theme));
-        if (isBooked) {
-            throw new ConflictException("해당 테마 이용시간이 겹칩니다.");
-        }
-    }
-
-    private void validatePastDateTime(final LocalDate date, final LocalTime time) {
-        final LocalDateTime now = LocalDateTime.now();
-        final LocalDateTime reservationDateTime = LocalDateTime.of(date, time);
-        if (reservationDateTime.isBefore(now)) {
-            throw new BadRequestException("현재보다 과거의 날짜로 예약 할 수 없습니다.");
-        }
     }
 
     private List<AvailableReservationTimeResponse> getAvailableReservationTimeResponses(

--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -1,6 +1,6 @@
 package roomescape.reservation.application;
 
-import static roomescape.reservation.domain.ReservationStatus.PENDING;
+import static roomescape.reservation.domain.PaymentStatus.PENDING;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -5,6 +5,8 @@ import static roomescape.reservation.domain.PaymentStatus.PENDING;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -115,7 +117,7 @@ public class ReservationService {
     }
 
     private void validatePastDateTime(final LocalDate date, final LocalTime time) {
-        final LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
         final LocalDateTime reservationDateTime = LocalDateTime.of(date, time);
         if (reservationDateTime.isBefore(now)) {
             throw new BadRequestException("현재보다 과거의 날짜로 예약 할 수 없습니다.");

--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -2,6 +2,7 @@ package roomescape.reservation.application;
 
 import static roomescape.reservation.domain.PaymentStatus.PENDING;
 
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,6 +20,7 @@ import roomescape.reservation.application.dto.AvailableReservationTimeResponse;
 import roomescape.reservation.application.dto.MemberReservationRequest;
 import roomescape.reservation.application.dto.MyReservation;
 import roomescape.reservation.application.dto.ReservationResponse;
+import roomescape.reservation.domain.PaymentStatus;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.ReservationTime;
 import roomescape.reservation.domain.repository.ReservationRepository;
@@ -56,6 +58,10 @@ public class ReservationService {
         return reservations.stream()
             .map(ReservationResponse::of)
             .toList();
+    }
+
+    public List<Reservation> findByCreateTimeAndPaymentStatus(Timestamp createdAtBefore, PaymentStatus paymentStatus) {
+        return reservationRepository.findByCreatedAtBeforeAndPaymentStatus(createdAtBefore, paymentStatus);
     }
 
     @Transactional

--- a/src/main/java/roomescape/reservation/application/dto/MemberReservationRequest.java
+++ b/src/main/java/roomescape/reservation/application/dto/MemberReservationRequest.java
@@ -6,10 +6,7 @@ import java.time.LocalDate;
 public record MemberReservationRequest(
     @NotNull LocalDate date,
     @NotNull Long timeId,
-    @NotNull Long themeId,
-    @NotNull String paymentKey,
-    @NotNull String orderId,
-    @NotNull Long amount
+    @NotNull Long themeId
 ) {
 
 }

--- a/src/main/java/roomescape/reservation/application/dto/MyReservation.java
+++ b/src/main/java/roomescape/reservation/application/dto/MyReservation.java
@@ -16,7 +16,6 @@ public record MyReservation(
     String status
 ) {
 
-    static final String RESERVED_STATUS = "예약";
     static final String WAITING_STATUS = "%s번째 예약대기";
 
     public static MyReservation from(Reservation reservation) {
@@ -25,7 +24,7 @@ public record MyReservation(
             reservation.getThemeName(),
             reservation.getDate(),
             reservation.getStartAt(),
-            RESERVED_STATUS
+            reservation.getPaymentStatusName()
         );
     }
 

--- a/src/main/java/roomescape/reservation/application/dto/MyReservationAndPaymentInfo.java
+++ b/src/main/java/roomescape/reservation/application/dto/MyReservationAndPaymentInfo.java
@@ -1,0 +1,42 @@
+package roomescape.reservation.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import roomescape.payment.domain.PaymentInfo;
+
+public record MyReservationAndPaymentInfo(
+    Long id,
+    String theme,
+    LocalDate date,
+    @JsonFormat(pattern = "HH:mm")
+    LocalTime time,
+    String status,
+    String paymentKey,
+    Long amount
+) {
+
+    public static MyReservationAndPaymentInfo from(MyReservation reservation, PaymentInfo paymentInfo) {
+        if (paymentInfo == null) {
+            return new MyReservationAndPaymentInfo(
+                reservation.id(),
+                reservation.theme(),
+                reservation.date(),
+                reservation.time(),
+                reservation.status(),
+                null,
+                null
+            );
+        }
+
+        return new MyReservationAndPaymentInfo(
+            reservation.id(),
+            reservation.theme(),
+            reservation.date(),
+            reservation.time(),
+            reservation.status(),
+            paymentInfo.getPaymentKey(),
+            paymentInfo.getAmount()
+        );
+    }
+}

--- a/src/main/java/roomescape/reservation/application/dto/MyReservationAndPaymentInfo.java
+++ b/src/main/java/roomescape/reservation/application/dto/MyReservationAndPaymentInfo.java
@@ -16,7 +16,8 @@ public record MyReservationAndPaymentInfo(
     Long amount
 ) {
 
-    public static MyReservationAndPaymentInfo from(MyReservation reservation, PaymentInfo paymentInfo) {
+    public static MyReservationAndPaymentInfo from(MyReservation reservation,
+        PaymentInfo paymentInfo) {
         if (paymentInfo == null) {
             return new MyReservationAndPaymentInfo(
                 reservation.id(),

--- a/src/main/java/roomescape/reservation/domain/PaymentStatus.java
+++ b/src/main/java/roomescape/reservation/domain/PaymentStatus.java
@@ -1,5 +1,17 @@
 package roomescape.reservation.domain;
 
 public enum PaymentStatus {
-    PENDING, SUCCESS
+
+    PENDING("결제 대기"),
+    SUCCESS("예약 완료");
+
+    private final String name;
+
+    PaymentStatus(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/roomescape/reservation/domain/PaymentStatus.java
+++ b/src/main/java/roomescape/reservation/domain/PaymentStatus.java
@@ -1,5 +1,5 @@
 package roomescape.reservation.domain;
 
-public enum ReservationStatus {
+public enum PaymentStatus {
     PENDING, SUCCESS
 }

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -1,6 +1,8 @@
 package roomescape.reservation.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -31,6 +33,9 @@ public class Reservation {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus reservationStatus;
+
     protected Reservation() {
 
     }
@@ -40,18 +45,20 @@ public class Reservation {
         final LocalDate date,
         final ReservationTime time,
         final Theme theme,
-        final Member member
+        final Member member,
+        final ReservationStatus reservationStatus
     ) {
         this.id = id;
         this.date = date;
         this.time = time;
         this.theme = theme;
         this.member = member;
+        this.reservationStatus = reservationStatus;
     }
 
     public Reservation(final LocalDate date, final ReservationTime time, final Theme theme,
-        final Member member) {
-        this(null, date, time, theme, member);
+        final Member member, ReservationStatus reservationStatus) {
+        this(null, date, time, theme, member, reservationStatus);
     }
 
     public boolean hasConflictWith(final ReservationTime reservationTime, final Theme theme) {
@@ -89,6 +96,10 @@ public class Reservation {
 
     public LocalTime getStartAt() {
         return time.getStartAt();
+    }
+
+    public ReservationStatus getReservationStatus() {
+        return reservationStatus;
     }
 
     @Override

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -105,6 +105,10 @@ public class Reservation {
         return createdAt;
     }
 
+    public String getPaymentStatusName() {
+        return paymentStatus.getName();
+    }
+
     public void changePaymentStatus(PaymentStatus paymentStatus) {
         this.paymentStatus = paymentStatus;
     }

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -1,5 +1,6 @@
 package roomescape.reservation.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -9,8 +10,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
-import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Objects;
 import roomescape.member.domain.Member;
@@ -42,7 +43,8 @@ public class Reservation {
     @OneToOne(mappedBy = "reservation", fetch = FetchType.LAZY)
     private Payment payment;
 
-    private final Timestamp createdAt = new Timestamp(System.currentTimeMillis());
+    @Column(nullable = false)
+    private final LocalDateTime createdAt = LocalDateTime.now();
 
     protected Reservation() {
 

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -12,6 +12,8 @@ import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 import roomescape.member.domain.Member;
 import roomescape.member.domain.MemberName;
@@ -21,7 +23,6 @@ import roomescape.theme.domain.Theme;
 @Entity
 public class Reservation {
 
-    private final LocalDateTime createdAt = LocalDateTime.now();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -36,6 +37,8 @@ public class Reservation {
     private PaymentStatus paymentStatus;
     @OneToOne(mappedBy = "reservation", fetch = FetchType.LAZY)
     private Payment payment;
+
+    private final LocalDateTime createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
 
     protected Reservation() {
 

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -8,12 +8,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Objects;
 import roomescape.member.domain.Member;
 import roomescape.member.domain.MemberName;
+import roomescape.payment.domain.Payment;
 import roomescape.theme.domain.Theme;
 
 @Entity
@@ -36,6 +38,9 @@ public class Reservation {
 
     @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
+
+    @OneToOne(mappedBy = "reservation", fetch = FetchType.LAZY)
+    private Payment payment;
 
     private final Timestamp createdAt = new Timestamp(System.currentTimeMillis());
 
@@ -101,8 +106,8 @@ public class Reservation {
         return time.getStartAt();
     }
 
-    public Timestamp getCreatedAt() {
-        return createdAt;
+    public Payment getPayment() {
+        return payment;
     }
 
     public String getPaymentStatusName() {

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Objects;
@@ -35,6 +36,8 @@ public class Reservation {
 
     @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
+
+    private final Timestamp createdAt = new Timestamp(System.currentTimeMillis());
 
     protected Reservation() {
 
@@ -96,6 +99,10 @@ public class Reservation {
 
     public LocalTime getStartAt() {
         return time.getStartAt();
+    }
+
+    public Timestamp getCreatedAt() {
+        return createdAt;
     }
 
     public void changePaymentStatus(PaymentStatus paymentStatus) {

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -21,28 +21,21 @@ import roomescape.theme.domain.Theme;
 @Entity
 public class Reservation {
 
+    private final LocalDateTime createdAt = LocalDateTime.now();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private LocalDate date;
-
     @ManyToOne(fetch = FetchType.LAZY)
     private ReservationTime time;
-
     @ManyToOne(fetch = FetchType.LAZY)
     private Theme theme;
-
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
-
     @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
-
     @OneToOne(mappedBy = "reservation", fetch = FetchType.LAZY)
     private Payment payment;
-
-    private final LocalDateTime createdAt = LocalDateTime.now();
 
     protected Reservation() {
 

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -1,6 +1,5 @@
 package roomescape.reservation.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -43,7 +42,6 @@ public class Reservation {
     @OneToOne(mappedBy = "reservation", fetch = FetchType.LAZY)
     private Payment payment;
 
-    @Column(nullable = false)
     private final LocalDateTime createdAt = LocalDateTime.now();
 
     protected Reservation() {

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -34,7 +34,7 @@ public class Reservation {
     private Member member;
 
     @Enumerated(EnumType.STRING)
-    private ReservationStatus reservationStatus;
+    private PaymentStatus paymentStatus;
 
     protected Reservation() {
 
@@ -46,19 +46,19 @@ public class Reservation {
         final ReservationTime time,
         final Theme theme,
         final Member member,
-        final ReservationStatus reservationStatus
+        final PaymentStatus paymentStatus
     ) {
         this.id = id;
         this.date = date;
         this.time = time;
         this.theme = theme;
         this.member = member;
-        this.reservationStatus = reservationStatus;
+        this.paymentStatus = paymentStatus;
     }
 
     public Reservation(final LocalDate date, final ReservationTime time, final Theme theme,
-        final Member member, ReservationStatus reservationStatus) {
-        this(null, date, time, theme, member, reservationStatus);
+        final Member member, PaymentStatus paymentStatus) {
+        this(null, date, time, theme, member, paymentStatus);
     }
 
     public boolean hasConflictWith(final ReservationTime reservationTime, final Theme theme) {
@@ -98,8 +98,8 @@ public class Reservation {
         return time.getStartAt();
     }
 
-    public ReservationStatus getReservationStatus() {
-        return reservationStatus;
+    public void changePaymentStatus(PaymentStatus paymentStatus) {
+        this.paymentStatus = paymentStatus;
     }
 
     @Override

--- a/src/main/java/roomescape/reservation/domain/ReservationStatus.java
+++ b/src/main/java/roomescape/reservation/domain/ReservationStatus.java
@@ -1,0 +1,5 @@
+package roomescape.reservation.domain;
+
+public enum ReservationStatus {
+    PENDING, SUCCESS
+}

--- a/src/main/java/roomescape/reservation/domain/ReservationWaitingInfo.java
+++ b/src/main/java/roomescape/reservation/domain/ReservationWaitingInfo.java
@@ -9,7 +9,7 @@
 //import java.util.Objects;
 //import roomescape.theme.domain.Theme;
 //
-///***
+/// ***
 // * 추후에 사용할 코드입니다.
 // */
 //@Entity

--- a/src/main/java/roomescape/reservation/domain/ReservationWaitingInfo.java
+++ b/src/main/java/roomescape/reservation/domain/ReservationWaitingInfo.java
@@ -1,75 +1,75 @@
-package roomescape.reservation.domain;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import java.time.LocalDate;
-import java.util.Objects;
-import roomescape.theme.domain.Theme;
-
-/***
- * 추후에 사용할 코드입니다.
- */
-@Entity
-public class ReservationWaitingInfo {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @ManyToOne(optional = false)
-    private Theme theme;
-
-    @ManyToOne(optional = false)
-    private ReservationTime reservationTime;
-
-    private LocalDate date;
-
-    public ReservationWaitingInfo() {
-    }
-
-    public ReservationWaitingInfo(
-        Long id, Theme theme,
-        ReservationTime reservationTime, LocalDate date) {
-        this.id = id;
-        this.theme = theme;
-        this.reservationTime = reservationTime;
-        this.date = date;
-    }
-
-    public ReservationWaitingInfo(Theme theme, ReservationTime reservationTime, LocalDate date) {
-        this(null, theme, reservationTime, date);
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public Theme getTheme() {
-        return theme;
-    }
-
-    public ReservationTime getReservationTime() {
-        return reservationTime;
-    }
-
-    public LocalDate getDate() {
-        return date;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ReservationWaitingInfo that = (ReservationWaitingInfo) o;
-        return Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(id);
-    }
-}
+//package roomescape.reservation.domain;
+//
+//import jakarta.persistence.Entity;
+//import jakarta.persistence.GeneratedValue;
+//import jakarta.persistence.GenerationType;
+//import jakarta.persistence.Id;
+//import jakarta.persistence.ManyToOne;
+//import java.time.LocalDate;
+//import java.util.Objects;
+//import roomescape.theme.domain.Theme;
+//
+///***
+// * 추후에 사용할 코드입니다.
+// */
+//@Entity
+//public class ReservationWaitingInfo {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//
+//    @ManyToOne(optional = false)
+//    private Theme theme;
+//
+//    @ManyToOne(optional = false)
+//    private ReservationTime reservationTime;
+//
+//    private LocalDate date;
+//
+//    public ReservationWaitingInfo() {
+//    }
+//
+//    public ReservationWaitingInfo(
+//        Long id, Theme theme,
+//        ReservationTime reservationTime, LocalDate date) {
+//        this.id = id;
+//        this.theme = theme;
+//        this.reservationTime = reservationTime;
+//        this.date = date;
+//    }
+//
+//    public ReservationWaitingInfo(Theme theme, ReservationTime reservationTime, LocalDate date) {
+//        this(null, theme, reservationTime, date);
+//    }
+//
+//    public Long getId() {
+//        return id;
+//    }
+//
+//    public Theme getTheme() {
+//        return theme;
+//    }
+//
+//    public ReservationTime getReservationTime() {
+//        return reservationTime;
+//    }
+//
+//    public LocalDate getDate() {
+//        return date;
+//    }
+//
+//    @Override
+//    public boolean equals(Object o) {
+//        if (o == null || getClass() != o.getClass()) {
+//            return false;
+//        }
+//        ReservationWaitingInfo that = (ReservationWaitingInfo) o;
+//        return Objects.equals(id, that.id);
+//    }
+//
+//    @Override
+//    public int hashCode() {
+//        return Objects.hashCode(id);
+//    }
+//}

--- a/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
@@ -27,5 +27,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findByMemberId(Long memberId);
 
-    List<Reservation> findByCreatedAtBeforeAndPaymentStatus(LocalDateTime createdAtBefore, PaymentStatus paymentStatus);
+    List<Reservation> findByCreatedAtBeforeAndPaymentStatus(LocalDateTime createdAtBefore,
+        PaymentStatus paymentStatus);
 }

--- a/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
@@ -1,7 +1,7 @@
 package roomescape.reservation.domain.repository;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -27,5 +27,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findByMemberId(Long memberId);
 
-    List<Reservation> findByCreatedAtBeforeAndPaymentStatus(Timestamp createdAtBefore, PaymentStatus paymentStatus);
+    List<Reservation> findByCreatedAtBeforeAndPaymentStatus(LocalDateTime createdAtBefore, PaymentStatus paymentStatus);
 }

--- a/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
@@ -1,9 +1,11 @@
 package roomescape.reservation.domain.repository;
 
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import roomescape.reservation.domain.PaymentStatus;
 import roomescape.reservation.domain.Reservation;
 
 @Repository
@@ -24,4 +26,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         LocalDate date);
 
     List<Reservation> findByMemberId(Long memberId);
+
+    List<Reservation> findByCreatedAtBeforeAndPaymentStatus(Timestamp createdAtBefore, PaymentStatus paymentStatus);
 }

--- a/src/main/java/roomescape/reservation/ui/UserReservationController.java
+++ b/src/main/java/roomescape/reservation/ui/UserReservationController.java
@@ -15,7 +15,7 @@ import roomescape.login.application.dto.LoginCheckRequest;
 import roomescape.reservation.application.ReservationService;
 import roomescape.reservation.application.dto.AvailableReservationTimeResponse;
 import roomescape.reservation.application.dto.MemberReservationRequest;
-import roomescape.reservation.application.dto.MyReservation;
+import roomescape.reservation.application.dto.MyReservationAndPaymentInfo;
 import roomescape.reservation.application.dto.ReservationResponse;
 
 @RestController
@@ -40,8 +40,8 @@ public class UserReservationController {
     }
 
     @GetMapping("/mine")
-    public ResponseEntity<List<MyReservation>> findMyReservations(final LoginCheckRequest request) {
-        List<MyReservation> response = reservationService.findByMemberId(request.id());
+    public ResponseEntity<List<MyReservationAndPaymentInfo>> findMyReservations(final LoginCheckRequest request) {
+        List<MyReservationAndPaymentInfo> response = reservationService.findByMemberId(request.id());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/roomescape/reservation/ui/UserReservationController.java
+++ b/src/main/java/roomescape/reservation/ui/UserReservationController.java
@@ -40,8 +40,10 @@ public class UserReservationController {
     }
 
     @GetMapping("/mine")
-    public ResponseEntity<List<MyReservationAndPaymentInfo>> findMyReservations(final LoginCheckRequest request) {
-        List<MyReservationAndPaymentInfo> response = reservationService.findByMemberId(request.id());
+    public ResponseEntity<List<MyReservationAndPaymentInfo>> findMyReservations(
+        final LoginCheckRequest request) {
+        List<MyReservationAndPaymentInfo> response = reservationService.findByMemberId(
+            request.id());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/roomescape/waiting/domain/Waiting.java
+++ b/src/main/java/roomescape/waiting/domain/Waiting.java
@@ -1,5 +1,7 @@
 package roomescape.waiting.domain;
 
+import static roomescape.reservation.domain.ReservationStatus.PENDING;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -60,7 +62,7 @@ public class Waiting {
 
     public Reservation convertToReservation() {
         return new Reservation(
-            this.getDate(), this.getReservationTime(), this.getTheme(), this.getMember()
+            this.getDate(), this.getReservationTime(), this.getTheme(), this.getMember(), PENDING
         );
     }
 

--- a/src/main/java/roomescape/waiting/domain/Waiting.java
+++ b/src/main/java/roomescape/waiting/domain/Waiting.java
@@ -1,6 +1,6 @@
 package roomescape.waiting.domain;
 
-import static roomescape.reservation.domain.ReservationStatus.PENDING;
+import static roomescape.reservation.domain.PaymentStatus.PENDING;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,6 @@ spring:
       data-locations: classpath:data.sql
 
   jpa:
-    show-sql: true
     hibernate:
       ddl-auto: create-drop
     properties:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,3 +34,8 @@ scheduler:
     time: 60000 # 1분
   valid:
     period: 60s
+
+
+logging:
+  level:
+    root: info

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,3 +29,9 @@ security:
       secret-key: s8R$kQz3nZ!L5pT7c@J#xM9vB1&uD6hE
       access:
         expire-length: 600000 # 10 분
+
+scheduler:
+  request:
+    time: 60000 # 1분
+  valid:
+    period: 60s

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -36,17 +36,17 @@ VALUES ('컨저링', '실화 기반의 공포가 현실이 된다, 악령이 도
 
 -- 2 -> 1 -> 3
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -2, CURRENT_DATE), 2, 2, 5);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -2, CURRENT_DATE), 2, 2, 5, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -2, CURRENT_DATE), 3, 2, 5);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -2, CURRENT_DATE), 3, 2, 5, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -2, CURRENT_DATE), 2, 1, 6);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -2, CURRENT_DATE), 2, 1, 6, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -2, CURRENT_DATE), 1, 1, 6);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -2, CURRENT_DATE), 1, 1, 6, 'SUCCESS');
 
 INSERT INTO waiting(date, id, member_id, reservation_time_id, theme_id)
 VALUES (DATEADD('DAY', -2, CURRENT_DATE), 1, 6, 2, 2);
@@ -56,17 +56,17 @@ VALUES (DATEADD('DAY', -2, CURRENT_DATE), 2, 6, 3, 2);
 
 
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -4, CURRENT_DATE), 2, 2, 1);
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 2, 2, 2);
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 3, 1, 2);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -4, CURRENT_DATE), 2, 2, 1, 'SUCCESS');
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 2, 2, 2, 'SUCCESS');
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 3, 1, 2, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 1, 3);
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 3, 3);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 1, 3, 'SUCCESS');
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 3, 3, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 1, 2, 1);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 1, 2, 1, 'SUCCESS');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -36,16 +36,16 @@ VALUES ('컨저링', '실화 기반의 공포가 현실이 된다, 악령이 도
 
 -- 2 -> 1 -> 3
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -2, CURRENT_DATE), 2, 2, 5, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -2, CURRENT_DATE), 3, 2, 5, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -2, CURRENT_DATE), 2, 1, 6, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -2, CURRENT_DATE), 1, 1, 6, 'SUCCESS');
 
 INSERT INTO waiting(date, id, member_id, reservation_time_id, theme_id)
@@ -56,17 +56,17 @@ VALUES (DATEADD('DAY', -2, CURRENT_DATE), 2, 6, 3, 2);
 
 
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -4, CURRENT_DATE), 2, 2, 1, 'SUCCESS');
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 2, 2, 2, 'SUCCESS');
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 3, 1, 2, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 1, 3, 'SUCCESS');
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 3, 3, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 1, 2, 1, 'SUCCESS');

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,13 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+  <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%level] [%logger] [request_id=%X{request_id}] - %msg%n" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- [%X{request_id}]를 추가하여 request_id 출력 -->
-      <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%level] [%logger] [request_id=%X{request_id}] - %msg%n</pattern>
+      <pattern>${LOG_PATTERN}</pattern>
+      </encoder>
+  </appender>
+
+  <appender name="ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>logs/my-application.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>//home/ubuntu/app/my-application-%d{yyyy-MM-dd_HH-mm}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
     </encoder>
   </appender>
 
   <root level="INFO">
-    <appender-ref ref="CONSOLE" />
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="ROLLING_FILE" />
   </root>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -11,7 +11,7 @@
   <appender name="ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>logs/my-application.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>//home/ubuntu/app/my-application-%d{yyyy-MM-dd_HH-mm}.log</fileNamePattern>
+      <fileNamePattern>//home/ubuntu/app/my-application-%d{yyyy-MM-dd}.log</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
     <encoder>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%level] [%logger] [request_id=%X{request_id}] - %msg%n" />
-
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>${LOG_PATTERN}</pattern>
-      </encoder>
-  </appender>
-
-  <appender name="ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>logs/my-application.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>//home/ubuntu/app/my-application-%d{yyyy-MM-dd}.log</fileNamePattern>
-      <maxHistory>30</maxHistory>
-    </rollingPolicy>
+  <appender class="ch.qos.logback.core.ConsoleAppender" name="STDOUT">
     <encoder>
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
   </appender>
 
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="ROLLING_FILE">
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
+    </encoder>
+    <file>logs/my-application.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>//home/ubuntu/app/my-application-%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <property name="LOG_PATTERN"
+    value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%level] [%logger] [request_id=%X{request_id}] - %msg%n"/>
+
   <root level="INFO">
-    <appender-ref ref="STDOUT" />
-    <appender-ref ref="ROLLING_FILE" />
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="ROLLING_FILE"/>
   </root>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- [%X{request_id}]를 추가하여 request_id 출력 -->
+      <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%level] [%logger] [request_id=%X{request_id}] - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
+  </root>
+</configuration>

--- a/src/main/resources/static/js/payment.js
+++ b/src/main/resources/static/js/payment.js
@@ -1,0 +1,96 @@
+document.addEventListener('DOMContentLoaded', () => {
+
+  // ------  결제위젯 초기화 ------
+  // @docs https://docs.tosspayments.com/reference/widget-sdk#sdk-설치-및-초기화
+  // @docs https://docs.tosspayments.com/reference/widget-sdk#renderpaymentmethods선택자-결제-금액-옵션
+  const paymentAmount = 1000;
+  const widgetClientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
+  const paymentWidget = PaymentWidget(widgetClientKey, PaymentWidget.ANONYMOUS);
+  paymentWidget.renderPaymentMethods(
+      "#payment-method",
+      {value: paymentAmount},
+      {variantKey: "DEFAULT"}
+  );
+
+  function onReservationButtonClickWithPaymentWidget(event) {
+    onReservationButtonClick(event, paymentWidget);
+  }
+});
+
+function onReservationButtonClick(event, paymentWidget) {
+  const selectedDate = document.getElementById("datepicker").value;
+  const selectedThemeId = document.querySelector('.theme-slot.active')?.getAttribute('data-theme-id');
+  const selectedTimeId = document.querySelector('.time-slot.active')?.getAttribute('data-time-id');
+
+  if (selectedDate && selectedThemeId && selectedTimeId) {
+    const reservationData = {
+      date: selectedDate,
+      themeId: selectedThemeId,
+      timeId: selectedTimeId
+    };
+    const generateRandomString = () =>
+        window.btoa(Math.random()).slice(0, 20);
+    /*
+    TODO: [1단계]
+          - orderIdPrefix 를 자신만의 prefix로 변경
+    */
+    // TOSS 결제 위젯 Javascript SDK 연동 방식 중 'Promise로 처리하기'를 적용함
+    // https://docs.tosspayments.com/reference/widget-sdk#promise%EB%A1%9C-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0
+    const orderIdPrefix = "WTEST";
+    paymentWidget.requestPayment({
+      orderId: orderIdPrefix + generateRandomString(),
+      orderName: "테스트 방탈출 예약 결제 1건",
+      amount: 1000,
+    }).then(function (data) {
+      console.debug(data);
+      fetchReservationPayment(data, reservationData);
+    }).catch(function (error) {
+      // TOSS 에러 처리: 에러 목록을 확인하세요
+      // https://docs.tosspayments.com/reference/error-codes#failurl 로-전달되는-에러
+      alert(error.code + " :" + error.message + "/ orderId : " + err.orderId);
+    });
+  } else {
+    alert("Please select a date, theme, and time before making a reservation.");
+  }
+}
+
+async function fetchReservationPayment(paymentData, reservationData) {
+
+  const reservationPaymentRequest = {
+    reservationId: reservationData.id,
+    paymentKey: paymentData.paymentKey,
+    orderId: paymentData.orderId,
+    amount: paymentData.amount,
+  }
+
+  const reservationURL = "/reservations";
+  fetch(reservationURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(reservationPaymentRequest),
+  }).then(response => {
+    if (!response.ok) {
+      return response.json().then(errorBody => {
+        console.error("예약 결제 실패 : " + JSON.stringify(errorBody));
+        window.alert("예약 결제 실패 메시지");
+      });
+    } else {
+      response.json().then(successBody => {
+        console.log("예약 결제 성공 : " + JSON.stringify(successBody));
+        window.location.reload();
+      });
+    }
+  }).catch(error => {
+    console.error(error.message);
+  });
+}
+
+function requestRead(endpoint) {
+  return fetch(endpoint)
+  .then(response => {
+    if (response.status === 200) return response.json();
+    throw new Error('Read failed');
+  });
+}

--- a/src/main/resources/static/js/payment.js
+++ b/src/main/resources/static/js/payment.js
@@ -10,8 +10,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   paymentWidget.renderPaymentMethods(
       "#payment-method",
-      { value: paymentAmount },
-      { variantKey: "DEFAULT" }
+      {value: paymentAmount},
+      {variantKey: "DEFAULT"}
   );
 
   const reserveButton = document.getElementById("payment-button");
@@ -58,7 +58,7 @@ async function fetchReservationPayment(paymentData, reservationId) {
   try {
     const response = await fetch(reservationURL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {"Content-Type": "application/json"},
       body: JSON.stringify(reservationPaymentRequest),
     });
 

--- a/src/main/resources/static/js/payment.js
+++ b/src/main/resources/static/js/payment.js
@@ -1,96 +1,79 @@
-document.addEventListener('DOMContentLoaded', () => {
+function getReservationIdFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("reservationId");
+}
 
-  // ------  결제위젯 초기화 ------
-  // @docs https://docs.tosspayments.com/reference/widget-sdk#sdk-설치-및-초기화
-  // @docs https://docs.tosspayments.com/reference/widget-sdk#renderpaymentmethods선택자-결제-금액-옵션
+document.addEventListener('DOMContentLoaded', () => {
   const paymentAmount = 1000;
   const widgetClientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
   const paymentWidget = PaymentWidget(widgetClientKey, PaymentWidget.ANONYMOUS);
+
   paymentWidget.renderPaymentMethods(
       "#payment-method",
-      {value: paymentAmount},
-      {variantKey: "DEFAULT"}
+      { value: paymentAmount },
+      { variantKey: "DEFAULT" }
   );
 
-  function onReservationButtonClickWithPaymentWidget(event) {
+  const reserveButton = document.getElementById("payment-button");
+  reserveButton.addEventListener("click", (event) => {
     onReservationButtonClick(event, paymentWidget);
-  }
+  });
 });
 
 function onReservationButtonClick(event, paymentWidget) {
-  const selectedDate = document.getElementById("datepicker").value;
-  const selectedThemeId = document.querySelector('.theme-slot.active')?.getAttribute('data-theme-id');
-  const selectedTimeId = document.querySelector('.time-slot.active')?.getAttribute('data-time-id');
+  const reservationId = getReservationIdFromUrl();
 
-  if (selectedDate && selectedThemeId && selectedTimeId) {
-    const reservationData = {
-      date: selectedDate,
-      themeId: selectedThemeId,
-      timeId: selectedTimeId
-    };
-    const generateRandomString = () =>
-        window.btoa(Math.random()).slice(0, 20);
-    /*
-    TODO: [1단계]
-          - orderIdPrefix 를 자신만의 prefix로 변경
-    */
-    // TOSS 결제 위젯 Javascript SDK 연동 방식 중 'Promise로 처리하기'를 적용함
-    // https://docs.tosspayments.com/reference/widget-sdk#promise%EB%A1%9C-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0
-    const orderIdPrefix = "WTEST";
-    paymentWidget.requestPayment({
-      orderId: orderIdPrefix + generateRandomString(),
-      orderName: "테스트 방탈출 예약 결제 1건",
-      amount: 1000,
-    }).then(function (data) {
-      console.debug(data);
-      fetchReservationPayment(data, reservationData);
-    }).catch(function (error) {
-      // TOSS 에러 처리: 에러 목록을 확인하세요
-      // https://docs.tosspayments.com/reference/error-codes#failurl 로-전달되는-에러
-      alert(error.code + " :" + error.message + "/ orderId : " + err.orderId);
-    });
-  } else {
-    alert("Please select a date, theme, and time before making a reservation.");
+  if (!reservationId) {
+    alert("예약 ID가 없습니다.");
+    return;
   }
+
+  const generateRandomString = () => window.btoa(Math.random()).slice(0, 20);
+  const orderIdPrefix = "WTEST";
+
+  paymentWidget.requestPayment({
+    orderId: orderIdPrefix + generateRandomString(),
+    orderName: "테스트 방탈출 예약 결제 1건",
+    amount: 1000,
+  })
+  .then(data => {
+    console.debug("결제 완료 응답:", data);
+    fetchReservationPayment(data, reservationId);
+  })
+  .catch(error => {
+    alert(error.code + " :" + error.message);
+  });
 }
 
-async function fetchReservationPayment(paymentData, reservationData) {
-
+async function fetchReservationPayment(paymentData, reservationId) {
   const reservationPaymentRequest = {
-    reservationId: reservationData.id,
+    reservationId: Number(reservationId), // Long 타입으로 변환
     paymentKey: paymentData.paymentKey,
     orderId: paymentData.orderId,
     amount: paymentData.amount,
-  }
+  };
 
-  const reservationURL = "/reservations";
-  fetch(reservationURL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(reservationPaymentRequest),
-  }).then(response => {
+  const reservationURL = "/payment";
+
+  try {
+    const response = await fetch(reservationURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(reservationPaymentRequest),
+    });
+
     if (!response.ok) {
-      return response.json().then(errorBody => {
-        console.error("예약 결제 실패 : " + JSON.stringify(errorBody));
-        window.alert("예약 결제 실패 메시지");
-      });
-    } else {
-      response.json().then(successBody => {
-        console.log("예약 결제 성공 : " + JSON.stringify(successBody));
-        window.location.reload();
-      });
+      const errorBody = await response.json();
+      console.error("예약 결제 실패:", errorBody);
+      alert("예약 결제 실패: " + (errorBody.message || "알 수 없는 오류"));
+      return;
     }
-  }).catch(error => {
-    console.error(error.message);
-  });
-}
 
-function requestRead(endpoint) {
-  return fetch(endpoint)
-  .then(response => {
-    if (response.status === 200) return response.json();
-    throw new Error('Read failed');
-  });
+    const successBody = await response.json();
+    console.log("예약 결제 성공:", successBody);
+    alert("예약 결제가 성공적으로 완료되었습니다!");
+  } catch (error) {
+    console.error("예약 결제 중 오류:", error);
+    alert("예약 결제 중 오류가 발생했습니다.");
+  }
 }

--- a/src/main/resources/static/js/reservation-mine.js
+++ b/src/main/resources/static/js/reservation-mine.js
@@ -32,8 +32,8 @@ function renderCombined(reservations, waitings) {
       date: r.date,
       time: r.time,
       status: r.status,
-      paymentKey : r.paymentKey,
-      amount : r.amount
+      paymentKey: r.paymentKey,
+      amount: r.amount
     })),
     ...waitings.map(w => ({
       id: w.id,
@@ -55,7 +55,6 @@ function renderCombined(reservations, waitings) {
     row.insertCell(3).textContent = item.status;
     row.insertCell(4).textContent = item.paymentKey;
     row.insertCell(5).textContent = item.amount;
-
 
     const cancelCell = row.insertCell(4);
     if (item.status.includes('예약대기')) {

--- a/src/main/resources/static/js/reservation-mine.js
+++ b/src/main/resources/static/js/reservation-mine.js
@@ -31,7 +31,9 @@ function renderCombined(reservations, waitings) {
       theme: r.theme,
       date: r.date,
       time: r.time,
-      status: r.status
+      status: r.status,
+      paymentKey : r.paymentKey,
+      amount : r.amount
     })),
     ...waitings.map(w => ({
       id: w.id,
@@ -51,6 +53,9 @@ function renderCombined(reservations, waitings) {
     row.insertCell(1).textContent = item.date;
     row.insertCell(2).textContent = item.time;
     row.insertCell(3).textContent = item.status;
+    row.insertCell(4).textContent = item.paymentKey;
+    row.insertCell(5).textContent = item.amount;
+
 
     const cancelCell = row.insertCell(4);
     if (item.status.includes('예약대기')) {
@@ -66,7 +71,7 @@ function renderCombined(reservations, waitings) {
       payButton.textContent = '결제';
       payButton.className = 'btn btn-primary';
       payButton.onclick = function () {
-        window.location.href = `/payment?id=${item.id}`;
+        window.location.href = `/payment?reservationId=${item.id}`;
       };
       cancelCell.appendChild(payButton);
     } else {

--- a/src/main/resources/static/js/reservation-mine.js
+++ b/src/main/resources/static/js/reservation-mine.js
@@ -61,6 +61,14 @@ function renderCombined(reservations, waitings) {
         requestDeleteWaiting(item.id).then(() => window.location.reload());
       };
       cancelCell.appendChild(cancelButton);
+    } else if (item.status.includes('결제 대기')) {
+      const payButton = document.createElement('button');
+      payButton.textContent = '결제';
+      payButton.className = 'btn btn-primary';
+      payButton.onclick = function () {
+        window.location.href = `/payment?id=${item.id}`;
+      };
+      cancelCell.appendChild(payButton);
     } else {
       cancelCell.textContent = '';
     }

--- a/src/main/resources/static/js/user-reservation.js
+++ b/src/main/resources/static/js/user-reservation.js
@@ -2,8 +2,8 @@ const THEME_API_ENDPOINT = '/themes';
 
 document.addEventListener('DOMContentLoaded', () => {
     requestRead(THEME_API_ENDPOINT)
-        .then(renderTheme)
-        .catch(error => console.error('Error fetching times:', error));
+    .then(renderTheme)
+    .catch(error => console.error('Error fetching times:', error));
 
     flatpickr("#datepicker", {
         inline: true,
@@ -12,18 +12,6 @@ document.addEventListener('DOMContentLoaded', () => {
             checkDate();
         }
     });
-
-    // ------  결제위젯 초기화 ------
-    // @docs https://docs.tosspayments.com/reference/widget-sdk#sdk-설치-및-초기화
-    // @docs https://docs.tosspayments.com/reference/widget-sdk#renderpaymentmethods선택자-결제-금액-옵션
-    const paymentAmount = 1000;
-    const widgetClientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
-    const paymentWidget = PaymentWidget(widgetClientKey, PaymentWidget.ANONYMOUS);
-    paymentWidget.renderPaymentMethods(
-        "#payment-method",
-        {value: paymentAmount},
-        {variantKey: "DEFAULT"}
-    );
 
     document.getElementById('theme-slots').addEventListener('click', event => {
         if (event.target.classList.contains('theme-slot')) {
@@ -41,11 +29,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    document.getElementById('reserve-button').addEventListener('click', onReservationButtonClickWithPaymentWidget);
+    document.getElementById('reserve-button').addEventListener('click', onReservationButtonClick);
     document.getElementById('wait-button').addEventListener('click', onWaitButtonClick);
-    function onReservationButtonClickWithPaymentWidget(event) {
-        onReservationButtonClick(event, paymentWidget);
-    }
+
 });
 
 function renderTheme(themes) {
@@ -81,8 +67,8 @@ function checkDate() {
         timeSlots.innerHTML = '';
 
         requestRead(THEME_API_ENDPOINT)
-            .then(renderTheme)
-            .catch(error => console.error('Error fetching times:', error));
+        .then(renderTheme)
+        .catch(error => console.error('Error fetching times:', error));
     }
 }
 
@@ -105,7 +91,7 @@ function fetchAvailableTimes(date, themeId) {
         if (response.status === 200) return response.json();
         throw new Error('Read failed');
     }).then(renderAvailableTimes)
-        .catch(error => console.error("Error fetching available times:", error));
+    .catch(error => console.error("Error fetching available times:", error));
 }
 
 function renderAvailableTimes(times) {
@@ -156,88 +142,43 @@ function checkDateAndThemeAndTime() {
     }
 }
 
-function onReservationButtonClick(event, paymentWidget) {
+function onReservationButtonClick() {
     const selectedDate = document.getElementById("datepicker").value;
     const selectedThemeId = document.querySelector('.theme-slot.active')?.getAttribute('data-theme-id');
     const selectedTimeId = document.querySelector('.time-slot.active')?.getAttribute('data-time-id');
+    // const name = document.getElementById('user-name').value;
 
     if (selectedDate && selectedThemeId && selectedTimeId) {
 
-        /*
-        TODO: [5단계] 예약 생성 기능 변경 - 사용자
-              request 명세에 맞게 설정
-        */
         const reservationData = {
             date: selectedDate,
             themeId: selectedThemeId,
             timeId: selectedTimeId,
+            // name: name
         };
 
-        const generateRandomString = () =>
-            window.btoa(Math.random()).slice(0, 20);
-        /*
-        TODO: [1단계]
-              - orderIdPrefix 를 자신만의 prefix로 변경
-        */
-        // TOSS 결제 위젯 Javascript SDK 연동 방식 중 'Promise로 처리하기'를 적용함
-        // https://docs.tosspayments.com/reference/widget-sdk#promise%EB%A1%9C-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0
-        const orderIdPrefix = "WTEST";
-        paymentWidget.requestPayment({
-            orderId: orderIdPrefix + generateRandomString(),
-            orderName: "테스트 방탈출 예약 결제 1건",
-            amount: 1000,
-        }).then(function (data) {
-            console.debug(data);
-            fetchReservationPayment(data, reservationData);
-        }).catch(function (error) {
-            // TOSS 에러 처리: 에러 목록을 확인하세요
-            // https://docs.tosspayments.com/reference/error-codes#failurl 로-전달되는-에러
-            alert(error.code + " :" + error.message + "/ orderId : " + err.orderId);
+        fetch('/reservations', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(reservationData)
+        })
+        .then(response => {
+            if (!response.ok) throw new Error('Reservation failed');
+            return response.json();
+        })
+        .then(data => {
+            const reservationId = data.id
+            window.location.href = `/payment?reservationId=${reservationId}`;
+        })
+        .catch(error => {
+            alert("An error occurred while making the reservation.");
+            console.error(error);
         });
     } else {
         alert("Please select a date, theme, and time before making a reservation.");
     }
-}
-
-async function fetchReservationPayment(paymentData, reservationData) {
-    /*
-    TODO: [1단계]
-        - 자신의 예약 API request에 맞게 reservationPaymentRequest 필드명 수정
-        - 내 서버 URL에 맞게 reservationURL 변경
-        - 예약 결제 실패 시, 사용자가 실패 사유를 알 수 있도록 alert 에서 에러 메시지 수정
-    */
-    const reservationPaymentRequest = {
-        date: reservationData.date,
-        themeId: reservationData.themeId,
-        timeId: reservationData.timeId,
-        paymentKey: paymentData.paymentKey,
-        orderId: paymentData.orderId,
-        amount: paymentData.amount,
-        paymentType: paymentData.paymentType,
-    }
-
-    const reservationURL = "/reservations";
-    fetch(reservationURL, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(reservationPaymentRequest),
-    }).then(response => {
-        if (!response.ok) {
-            return response.text().then(errorBody => {
-                console.error("예약 결제 실패 : " + JSON.stringify(errorBody));
-                window.alert(JSON.stringify(errorBody));
-            });
-        } else {
-            response.json().then(successBody => {
-                console.log("예약 결제 성공 : " + JSON.stringify(successBody));
-                window.location.reload();
-            });
-        }
-    }).catch(error => {
-        console.error(error.message);
-    });
 }
 
 function onWaitButtonClick() {
@@ -252,9 +193,6 @@ function onWaitButtonClick() {
             themeId: selectedThemeId
         };
 
-        /*
-        TODO: [3단계] 예약 대기 생성 요청 API 호출
-         */
         fetch('/waitings', {
             method: 'POST',
             headers: {
@@ -282,8 +220,8 @@ function onWaitButtonClick() {
 
 function requestRead(endpoint) {
     return fetch(endpoint)
-        .then(response => {
-            if (response.status === 200) return response.json();
-            throw new Error('Read failed');
-        });
+    .then(response => {
+        if (response.status === 200) return response.json();
+        throw new Error('Read failed');
+    });
 }

--- a/src/main/resources/static/js/user-reservation.js
+++ b/src/main/resources/static/js/user-reservation.js
@@ -1,227 +1,245 @@
 const THEME_API_ENDPOINT = '/themes';
 
 document.addEventListener('DOMContentLoaded', () => {
-    requestRead(THEME_API_ENDPOINT)
-    .then(renderTheme)
-    .catch(error => console.error('Error fetching times:', error));
+  requestRead(THEME_API_ENDPOINT)
+  .then(renderTheme)
+  .catch(error => console.error('Error fetching times:', error));
 
-    flatpickr("#datepicker", {
-        inline: true,
-        onChange: function (selectedDates, dateStr, instance) {
-            if (dateStr === '') return;
-            checkDate();
-        }
-    });
+  flatpickr("#datepicker", {
+    inline: true,
+    onChange: function (selectedDates, dateStr, instance) {
+      if (dateStr === '') {
+        return;
+      }
+      checkDate();
+    }
+  });
 
-    document.getElementById('theme-slots').addEventListener('click', event => {
-        if (event.target.classList.contains('theme-slot')) {
-            document.querySelectorAll('.theme-slot').forEach(slot => slot.classList.remove('active'));
-            event.target.classList.add('active');
-            checkDateAndTheme();
-        }
-    });
+  document.getElementById('theme-slots').addEventListener('click', event => {
+    if (event.target.classList.contains('theme-slot')) {
+      document.querySelectorAll('.theme-slot').forEach(
+          slot => slot.classList.remove('active'));
+      event.target.classList.add('active');
+      checkDateAndTheme();
+    }
+  });
 
-    document.getElementById('time-slots').addEventListener('click', event => {
-        if (event.target.classList.contains('time-slot') && !event.target.classList.contains('disabled')) {
-            document.querySelectorAll('.time-slot').forEach(slot => slot.classList.remove('active'));
-            event.target.classList.add('active');
-            checkDateAndThemeAndTime();
-        }
-    });
+  document.getElementById('time-slots').addEventListener('click', event => {
+    if (event.target.classList.contains('time-slot')
+        && !event.target.classList.contains('disabled')) {
+      document.querySelectorAll('.time-slot').forEach(
+          slot => slot.classList.remove('active'));
+      event.target.classList.add('active');
+      checkDateAndThemeAndTime();
+    }
+  });
 
-    document.getElementById('reserve-button').addEventListener('click', onReservationButtonClick);
-    document.getElementById('wait-button').addEventListener('click', onWaitButtonClick);
+  document.getElementById('reserve-button').addEventListener('click',
+      onReservationButtonClick);
+  document.getElementById('wait-button').addEventListener('click',
+      onWaitButtonClick);
 
 });
 
 function renderTheme(themes) {
-    const themeSlots = document.getElementById('theme-slots');
-    themeSlots.innerHTML = '';
-    themes.forEach(theme => {
-        const name = theme.name;
-        const themeId = theme.id;
+  const themeSlots = document.getElementById('theme-slots');
+  themeSlots.innerHTML = '';
+  themes.forEach(theme => {
+    const name = theme.name;
+    const themeId = theme.id;
 
-        themeSlots.appendChild(createSlot('theme', name, themeId));
-    });
+    themeSlots.appendChild(createSlot('theme', name, themeId));
+  });
 }
 
 function createSlot(type, text, id, booked) {
-    const div = document.createElement('div');
-    div.className = type + '-slot cursor-pointer bg-light border rounded p-3 mb-2';
-    div.textContent = text;
-    div.setAttribute('data-' + type + '-id', id);
-    if (type === 'time') {
-        div.setAttribute('data-time-booked', booked);
-    }
-    return div;
+  const div = document.createElement('div');
+  div.className = type
+      + '-slot cursor-pointer bg-light border rounded p-3 mb-2';
+  div.textContent = text;
+  div.setAttribute('data-' + type + '-id', id);
+  if (type === 'time') {
+    div.setAttribute('data-time-booked', booked);
+  }
+  return div;
 }
 
 function checkDate() {
-    const selectedDate = document.getElementById("datepicker").value;
-    if (selectedDate) {
-        const themeSection = document.getElementById("theme-section");
-        if (themeSection.classList.contains("disabled")) {
-            themeSection.classList.remove("disabled");
-        }
-        const timeSlots = document.getElementById('time-slots');
-        timeSlots.innerHTML = '';
-
-        requestRead(THEME_API_ENDPOINT)
-        .then(renderTheme)
-        .catch(error => console.error('Error fetching times:', error));
+  const selectedDate = document.getElementById("datepicker").value;
+  if (selectedDate) {
+    const themeSection = document.getElementById("theme-section");
+    if (themeSection.classList.contains("disabled")) {
+      themeSection.classList.remove("disabled");
     }
+    const timeSlots = document.getElementById('time-slots');
+    timeSlots.innerHTML = '';
+
+    requestRead(THEME_API_ENDPOINT)
+    .then(renderTheme)
+    .catch(error => console.error('Error fetching times:', error));
+  }
 }
 
 function checkDateAndTheme() {
-    const selectedDate = document.getElementById("datepicker").value;
-    const selectedThemeElement = document.querySelector('.theme-slot.active');
-    if (selectedDate && selectedThemeElement) {
-        const selectedThemeId = selectedThemeElement.getAttribute('data-theme-id');
-        fetchAvailableTimes(selectedDate, selectedThemeId);
-    }
+  const selectedDate = document.getElementById("datepicker").value;
+  const selectedThemeElement = document.querySelector('.theme-slot.active');
+  if (selectedDate && selectedThemeElement) {
+    const selectedThemeId = selectedThemeElement.getAttribute('data-theme-id');
+    fetchAvailableTimes(selectedDate, selectedThemeId);
+  }
 }
 
 function fetchAvailableTimes(date, themeId) {
-    fetch(`/reservations/themes/${themeId}/times?date=${date}`, { // 예약 가능 시간 조회 API endpoint
-        method: 'GET',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-    }).then(response => {
-        if (response.status === 200) return response.json();
-        throw new Error('Read failed');
-    }).then(renderAvailableTimes)
-    .catch(error => console.error("Error fetching available times:", error));
+  fetch(`/reservations/themes/${themeId}/times?date=${date}`, { // 예약 가능 시간 조회 API endpoint
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then(response => {
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error('Read failed');
+  }).then(renderAvailableTimes)
+  .catch(error => console.error("Error fetching available times:", error));
 }
 
 function renderAvailableTimes(times) {
-    const timeSection = document.getElementById("time-section");
-    if (timeSection.classList.contains("disabled")) {
-        timeSection.classList.remove("disabled");
-    }
+  const timeSection = document.getElementById("time-section");
+  if (timeSection.classList.contains("disabled")) {
+    timeSection.classList.remove("disabled");
+  }
 
-    const timeSlots = document.getElementById('time-slots');
-    timeSlots.innerHTML = '';
-    if (times.length === 0) {
-        timeSlots.innerHTML = '<div class="no-times">선택할 수 있는 시간이 없습니다.</div>';
-        return;
-    }
-    times.forEach(time => {
-        const startAt = time.startAt;
-        const timeId = time.id;
-        const alreadyBooked = time.isBooked;
+  const timeSlots = document.getElementById('time-slots');
+  timeSlots.innerHTML = '';
+  if (times.length === 0) {
+    timeSlots.innerHTML = '<div class="no-times">선택할 수 있는 시간이 없습니다.</div>';
+    return;
+  }
+  times.forEach(time => {
+    const startAt = time.startAt;
+    const timeId = time.id;
+    const alreadyBooked = time.isBooked;
 
-        const div = createSlot('time', startAt, timeId, alreadyBooked); // createSlot('time', 시작 시간, time id, 예약 여부)
-        timeSlots.appendChild(div);
-    });
+    const div = createSlot('time', startAt, timeId, alreadyBooked); // createSlot('time', 시작 시간, time id, 예약 여부)
+    timeSlots.appendChild(div);
+  });
 }
 
 function checkDateAndThemeAndTime() {
-    const selectedDate = document.getElementById("datepicker").value;
-    const selectedThemeElement = document.querySelector('.theme-slot.active');
-    const selectedTimeElement = document.querySelector('.time-slot.active');
-    const reserveButton = document.getElementById("reserve-button");
-    const waitButton = document.getElementById("wait-button");
+  const selectedDate = document.getElementById("datepicker").value;
+  const selectedThemeElement = document.querySelector('.theme-slot.active');
+  const selectedTimeElement = document.querySelector('.time-slot.active');
+  const reserveButton = document.getElementById("reserve-button");
+  const waitButton = document.getElementById("wait-button");
 
-
-
-    if (selectedDate && selectedThemeElement && selectedTimeElement) {
-        if (selectedTimeElement.getAttribute('data-time-booked') === 'true') {
-            // 선택된 시간이 이미 예약된 경우
-            reserveButton.classList.add("disabled");
-            waitButton.classList.remove("disabled"); // 예약 대기 버튼 활성화
-        } else {
-            // 선택된 시간이 예약 가능한 경우
-            reserveButton.classList.remove("disabled");
-            waitButton.classList.add("disabled"); // 예약 대기 버튼 비활성화
-        }
+  if (selectedDate && selectedThemeElement && selectedTimeElement) {
+    if (selectedTimeElement.getAttribute('data-time-booked') === 'true') {
+      // 선택된 시간이 이미 예약된 경우
+      reserveButton.classList.add("disabled");
+      waitButton.classList.remove("disabled"); // 예약 대기 버튼 활성화
     } else {
-        // 날짜, 테마, 시간 중 하나라도 선택되지 않은 경우
-        reserveButton.classList.add("disabled");
-        waitButton.classList.add("disabled");
+      // 선택된 시간이 예약 가능한 경우
+      reserveButton.classList.remove("disabled");
+      waitButton.classList.add("disabled"); // 예약 대기 버튼 비활성화
     }
+  } else {
+    // 날짜, 테마, 시간 중 하나라도 선택되지 않은 경우
+    reserveButton.classList.add("disabled");
+    waitButton.classList.add("disabled");
+  }
 }
 
 function onReservationButtonClick() {
-    const selectedDate = document.getElementById("datepicker").value;
-    const selectedThemeId = document.querySelector('.theme-slot.active')?.getAttribute('data-theme-id');
-    const selectedTimeId = document.querySelector('.time-slot.active')?.getAttribute('data-time-id');
-    // const name = document.getElementById('user-name').value;
+  const selectedDate = document.getElementById("datepicker").value;
+  const selectedThemeId = document.querySelector(
+      '.theme-slot.active')?.getAttribute('data-theme-id');
+  const selectedTimeId = document.querySelector(
+      '.time-slot.active')?.getAttribute('data-time-id');
+  // const name = document.getElementById('user-name').value;
 
-    if (selectedDate && selectedThemeId && selectedTimeId) {
+  if (selectedDate && selectedThemeId && selectedTimeId) {
 
-        const reservationData = {
-            date: selectedDate,
-            themeId: selectedThemeId,
-            timeId: selectedTimeId,
-            // name: name
-        };
+    const reservationData = {
+      date: selectedDate,
+      themeId: selectedThemeId,
+      timeId: selectedTimeId,
+      // name: name
+    };
 
-        fetch('/reservations', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(reservationData)
-        })
-        .then(response => {
-            if (!response.ok) throw new Error('Reservation failed');
-            return response.json();
-        })
-        .then(data => {
-            const reservationId = data.id
-            window.location.href = `/payment?reservationId=${reservationId}`;
-        })
-        .catch(error => {
-            alert("An error occurred while making the reservation.");
-            console.error(error);
-        });
-    } else {
-        alert("Please select a date, theme, and time before making a reservation.");
-    }
+    fetch('/reservations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(reservationData)
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Reservation failed');
+      }
+      return response.json();
+    })
+    .then(data => {
+      const reservationId = data.id
+      window.location.href = `/payment?reservationId=${reservationId}`;
+    })
+    .catch(error => {
+      alert("An error occurred while making the reservation.");
+      console.error(error);
+    });
+  } else {
+    alert("Please select a date, theme, and time before making a reservation.");
+  }
 }
 
 function onWaitButtonClick() {
-    const selectedDate = document.getElementById("datepicker").value;
-    const selectedThemeId = document.querySelector('.theme-slot.active')?.getAttribute('data-theme-id');
-    const selectedTimeId = document.querySelector('.time-slot.active')?.getAttribute('data-time-id');
+  const selectedDate = document.getElementById("datepicker").value;
+  const selectedThemeId = document.querySelector(
+      '.theme-slot.active')?.getAttribute('data-theme-id');
+  const selectedTimeId = document.querySelector(
+      '.time-slot.active')?.getAttribute('data-time-id');
 
-    if (selectedDate && selectedThemeId && selectedTimeId) {
-        const reservationData = {
-            date: selectedDate,
-            timeId: selectedTimeId,
-            themeId: selectedThemeId
-        };
+  if (selectedDate && selectedThemeId && selectedTimeId) {
+    const reservationData = {
+      date: selectedDate,
+      timeId: selectedTimeId,
+      themeId: selectedThemeId
+    };
 
-        fetch('/waitings', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(reservationData)
-        })
-        .then(response => {
-            if (!response.ok) throw new Error('Reservation waiting failed');
-            return response.json();
-        })
-        .then(data => {
-            alert('Reservation waiting successful!');
-            window.location.href = "/";
-        })
-        .catch(error => {
-            alert("An error occurred while making the reservation waiting.");
-            console.error(error);
-        });
-    } else {
-        alert("Please select a date, theme, and time before making a reservation waiting.");
-    }
+    fetch('/waitings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(reservationData)
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Reservation waiting failed');
+      }
+      return response.json();
+    })
+    .then(data => {
+      alert('Reservation waiting successful!');
+      window.location.href = "/";
+    })
+    .catch(error => {
+      alert("An error occurred while making the reservation waiting.");
+      console.error(error);
+    });
+  } else {
+    alert(
+        "Please select a date, theme, and time before making a reservation waiting.");
+  }
 }
 
-
 function requestRead(endpoint) {
-    return fetch(endpoint)
-    .then(response => {
-        if (response.status === 200) return response.json();
-        throw new Error('Read failed');
-    });
+  return fetch(endpoint)
+  .then(response => {
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error('Read failed');
+  });
 }

--- a/src/main/resources/templates/payment.html
+++ b/src/main/resources/templates/payment.html
@@ -31,7 +31,7 @@
     <div id="payment-method" class="w-100"></div>
     <div id="agreement" class="w-100"></div>
     <div class="btn-wrapper w-100">
-      <button id="reserve-button" class="btn primary w-100">예약하기</button>
+      <button id="payment-button" class="btn primary w-100">결제하기</button>
     </div>
   </div>
 </div>

--- a/src/main/resources/templates/payment.html
+++ b/src/main/resources/templates/payment.html
@@ -2,25 +2,30 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <title>방탈출 예약 페이지</title>
   <!-- Bootstrap CSS -->
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
-  <link rel="stylesheet" href="/css/reservation.css">
-  <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="/css/toss-style.css">
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+        rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+        rel="stylesheet">
+  <link href="/css/reservation.css" rel="stylesheet">
+  <link href="/css/style.css" rel="stylesheet">
+  <link href="/css/toss-style.css" rel="stylesheet">
   <script src="https://js.tosspayments.com/v1/payment-widget"></script>
 </head>
 <body>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="/">
-    <img src="https://avatars.githubusercontent.com/u/141792611?s=200&v=4" alt="LOGO" style="height: 40px;">
+    <img alt="LOGO" src="https://avatars.githubusercontent.com/u/141792611?s=200&v=4"
+         style="height: 40px;">
   </a>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
-          aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+  <button aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"
+          class="navbar-toggler"
+          data-target="#navbarSupportedContent" data-toggle="collapse"
+          type="button">
     <span class="navbar-toggler-icon"></span>
   </button>
 </nav>
@@ -28,10 +33,10 @@
 <!-- 결제창 ui -->
 <div class="wrapper w-100">
   <div class="max-w-540 w-100">
-    <div id="payment-method" class="w-100"></div>
-    <div id="agreement" class="w-100"></div>
+    <div class="w-100" id="payment-method"></div>
+    <div class="w-100" id="agreement"></div>
     <div class="btn-wrapper w-100">
-      <button id="payment-button" class="btn primary w-100">결제하기</button>
+      <button class="btn primary w-100" id="payment-button">결제하기</button>
     </div>
   </div>
 </div>

--- a/src/main/resources/templates/payment.html
+++ b/src/main/resources/templates/payment.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>방탈출 예약 페이지</title>
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+  <link rel="stylesheet" href="/css/reservation.css">
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/toss-style.css">
+  <script src="https://js.tosspayments.com/v1/payment-widget"></script>
+</head>
+<body>
+
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <a class="navbar-brand" href="/">
+    <img src="https://avatars.githubusercontent.com/u/141792611?s=200&v=4" alt="LOGO" style="height: 40px;">
+  </a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+</nav>
+
+<!-- 결제창 ui -->
+<div class="wrapper w-100">
+  <div class="max-w-540 w-100">
+    <div id="payment-method" class="w-100"></div>
+    <div id="agreement" class="w-100"></div>
+    <div class="btn-wrapper w-100">
+      <button id="reserve-button" class="btn primary w-100">예약하기</button>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="/js/payment.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/reservation-mine.html
+++ b/src/main/resources/templates/reservation-mine.html
@@ -60,7 +60,9 @@
       <th>날짜</th>
       <th>시간</th>
       <th>상태</th>
-      <th></th>
+      <th>대기 취소</th>
+      <th>paymentKey</th>
+      <th>결제금액</th>
     </tr>
     </thead>
     <tbody id="table-body">

--- a/src/main/resources/templates/reservation.html
+++ b/src/main/resources/templates/reservation.html
@@ -2,30 +2,23 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>방탈출 예약 페이지</title>
   <!-- Bootstrap CSS -->
-  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-        rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
-        rel="stylesheet">
-  <link href="/css/reservation.css" rel="stylesheet">
-  <link href="/css/style.css" rel="stylesheet">
-  <link href="/css/toss-style.css" rel="stylesheet">
-  <script src="https://js.tosspayments.com/v1/payment-widget"></script>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+  <link rel="stylesheet" href="/css/reservation.css">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="/">
-    <img alt="LOGO" src="https://avatars.githubusercontent.com/u/141792611?s=200&v=4"
-         style="height: 40px;">
+    <img src="https://avatars.githubusercontent.com/u/141792611?s=200&v=4" alt="LOGO" style="height: 40px;">
   </a>
-  <button aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"
-          class="navbar-toggler"
-          data-target="#navbarSupportedContent" data-toggle="collapse"
-          type="button">
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
 
@@ -38,13 +31,12 @@
         <a class="nav-link" href="/login">Login</a>
       </li>
       <li class="nav-item dropdown">
-        <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-toggle="dropdown"
-           href="#"
-           id="navbarDropdown" role="button">
-          <img alt="Profile" class="profile-image" src="/image/default-profile.png">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
+           aria-haspopup="true" aria-expanded="false">
+          <img class="profile-image" src="/image/default-profile.png" alt="Profile">
           <span id="profile-name">Profile</span> <!-- 프로필 이름을 넣을 span 추가 -->
         </a>
-        <div aria-labelledby="navbarDropdown" class="dropdown-menu">
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
           <a class="dropdown-item" href="/reservation-mine">My Reservation</a>
           <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="#" id="logout-btn">Logout</a>
@@ -55,9 +47,9 @@
 </nav>
 
 <!-- Content -->
-<div class="col-md-10 offset-md-1 p-5" id="content-container">
+<div id="content-container" class="col-md-10 offset-md-1 p-5">
   <h2 class="content-container-title">예약 페이지</h2>
-  <div class="d-flex" id="reservation-container">
+  <div class="d-flex" id="reservation-container" >
     <!-- Date Section -->
     <div class="section border rounded col-md-4 p-3" id="date-section">
       <h3 class="fs-5 text-center mb-3">날짜 선택</h3>
@@ -82,33 +74,11 @@
       </div>
     </div>
   </div>
-
-  <!--
-  TODO: [5단계] 예약 생성 기능 변경 - 사용자
-        적용 후 아래에 있는 User Name Input 삭제
-  -->
-  <!-- User Name Input -->
-  <!--  <div class="input-group mb-3 mt-4">-->
-  <!--    <span class="input-group-text" id="name">예약자명</span>-->
-  <!--    <input id="user-name" type="text" class="form-control" aria-label="Username" aria-describedby="name">-->
-  <!--  </div>-->
-
-  <!-- Reservation Button -->
   <div class="button-group float-right">
-    <button class="btn btn-secondary mt-3 disabled" id="wait-button">예약대기</button>
+    <button id="reserve-button" class="btn btn-primary mt-3 disabled">예약하기</button>
+    <button id="wait-button" class="btn btn-secondary mt-3 disabled">예약대기</button>
   </div>
 </div>
-</div>
-
-<!-- 결제창 ui -->
-<div class="wrapper w-100">
-  <div class="max-w-540 w-100">
-    <div class="w-100" id="payment-method"></div>
-    <div class="w-100" id="agreement"></div>
-    <div class="btn-wrapper w-100">
-      <button class="btn primary w-100" id="reserve-button">예약하기</button>
-    </div>
-  </div>
 </div>
 
 <script src="/js/user-scripts.js"></script>

--- a/src/main/resources/templates/reservation.html
+++ b/src/main/resources/templates/reservation.html
@@ -2,23 +2,28 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <title>방탈출 예약 페이지</title>
   <!-- Bootstrap CSS -->
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
-  <link rel="stylesheet" href="/css/reservation.css">
-  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+        rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+        rel="stylesheet">
+  <link href="/css/reservation.css" rel="stylesheet">
+  <link href="/css/style.css" rel="stylesheet">
 </head>
 <body>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="/">
-    <img src="https://avatars.githubusercontent.com/u/141792611?s=200&v=4" alt="LOGO" style="height: 40px;">
+    <img alt="LOGO" src="https://avatars.githubusercontent.com/u/141792611?s=200&v=4"
+         style="height: 40px;">
   </a>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
-          aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+  <button aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"
+          class="navbar-toggler"
+          data-target="#navbarSupportedContent" data-toggle="collapse"
+          type="button">
     <span class="navbar-toggler-icon"></span>
   </button>
 
@@ -31,12 +36,13 @@
         <a class="nav-link" href="/login">Login</a>
       </li>
       <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
-           aria-haspopup="true" aria-expanded="false">
-          <img class="profile-image" src="/image/default-profile.png" alt="Profile">
+        <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-toggle="dropdown"
+           href="#"
+           id="navbarDropdown" role="button">
+          <img alt="Profile" class="profile-image" src="/image/default-profile.png">
           <span id="profile-name">Profile</span> <!-- 프로필 이름을 넣을 span 추가 -->
         </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+        <div aria-labelledby="navbarDropdown" class="dropdown-menu">
           <a class="dropdown-item" href="/reservation-mine">My Reservation</a>
           <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="#" id="logout-btn">Logout</a>
@@ -47,9 +53,9 @@
 </nav>
 
 <!-- Content -->
-<div id="content-container" class="col-md-10 offset-md-1 p-5">
+<div class="col-md-10 offset-md-1 p-5" id="content-container">
   <h2 class="content-container-title">예약 페이지</h2>
-  <div class="d-flex" id="reservation-container" >
+  <div class="d-flex" id="reservation-container">
     <!-- Date Section -->
     <div class="section border rounded col-md-4 p-3" id="date-section">
       <h3 class="fs-5 text-center mb-3">날짜 선택</h3>
@@ -75,8 +81,8 @@
     </div>
   </div>
   <div class="button-group float-right">
-    <button id="reserve-button" class="btn btn-primary mt-3 disabled">예약하기</button>
-    <button id="wait-button" class="btn btn-secondary mt-3 disabled">예약대기</button>
+    <button class="btn btn-primary mt-3 disabled" id="reserve-button">예약하기</button>
+    <button class="btn btn-secondary mt-3 disabled" id="wait-button">예약대기</button>
   </div>
 </div>
 </div>

--- a/src/test/java/roomescape/login/AuthApiTest.java
+++ b/src/test/java/roomescape/login/AuthApiTest.java
@@ -82,7 +82,7 @@ public class AuthApiTest {
             .asString();
 
         // then
-        assertThat(message).isEqualTo("회원 정보가 존재하지 않습니다.");
+        assertThat(message).isEqualTo("잘못된 요청입니다.");
     }
 
     @Test

--- a/src/test/java/roomescape/login/application/JwtHandlerTest.java
+++ b/src/test/java/roomescape/login/application/JwtHandlerTest.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import roomescape.common.exception.impl.TokenExpiredException;
 import roomescape.common.exception.impl.UnauthorizedException;
 import roomescape.login.application.dto.Token;
 import roomescape.member.domain.Member;
@@ -75,7 +76,7 @@ class JwtHandlerTest {
             .compact();
 
         assertThatThrownBy(() -> jwtHandler.decode(expiredToken))
-            .isInstanceOf(UnauthorizedException.class)
+            .isInstanceOf(TokenExpiredException.class)
             .hasMessage("로그인 정보가 만료되었습니다.");
     }
 

--- a/src/test/java/roomescape/payment/application/PaymentServiceTest.java
+++ b/src/test/java/roomescape/payment/application/PaymentServiceTest.java
@@ -2,7 +2,6 @@ package roomescape.payment.application;
 
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
@@ -12,13 +11,11 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import roomescape.payment.application.dto.PaymentRequest;
+import roomescape.payment.application.dto.PaymentResponse;
 import roomescape.payment.application.dto.TossConfirmRequest;
 import roomescape.payment.application.dto.TossConfirmResponse;
 import roomescape.payment.application.dto.TossConfirmResponse.EasyPayInfo;
-import roomescape.payment.domain.Payment;
 import roomescape.payment.domain.PaymentInfo;
-import roomescape.reservation.domain.Reservation;
-import roomescape.reservation.domain.repository.ReservationRepository;
 
 @ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -31,16 +28,12 @@ class PaymentServiceTest {
     @Autowired
     private PaymentService paymentService;
 
-    @Autowired
-    private ReservationRepository reservationRepository;
-
     @Test
     void 결제_저장_테스트() {
         // given
         PaymentInfo paymentInfo = new PaymentInfo("key", "orderId", 1000L);
-        Reservation reservation = reservationRepository.findById(1L).get();
         PaymentRequest paymentRequest = new PaymentRequest(
-            reservation, paymentInfo.getPaymentKey(), paymentInfo.getOrderId(), paymentInfo.getAmount()
+            1L, paymentInfo.getPaymentKey(), paymentInfo.getOrderId(), paymentInfo.getAmount()
         );
         TossConfirmRequest tossConfirmRequest = new TossConfirmRequest(paymentRequest.paymentKey(),
             paymentRequest.orderId(), paymentRequest.amount());
@@ -53,13 +46,10 @@ class PaymentServiceTest {
             .thenReturn(tossConfirmResponse);
 
         // when
-        Payment payment = paymentService.addPayment(paymentRequest);
+        PaymentResponse paymentResponse = paymentService.addPayment(paymentRequest);
 
         // then
-        assertAll(
-            () -> assertThat(payment.getId()).isNotNull(),
-            () -> assertThat(payment.getPaymentInfo().equals(paymentInfo))
-        );
+        assertThat(paymentResponse.paymentId()).isNotNull();
     }
 }
 

--- a/src/test/java/roomescape/payment/application/PaymentServiceTest.java
+++ b/src/test/java/roomescape/payment/application/PaymentServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,7 +17,8 @@ import roomescape.payment.application.dto.TossConfirmResponse;
 import roomescape.payment.application.dto.TossConfirmResponse.EasyPayInfo;
 import roomescape.payment.domain.Payment;
 import roomescape.payment.domain.PaymentInfo;
-import roomescape.reservation.application.dto.MemberReservationRequest;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.repository.ReservationRepository;
 
 @ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -31,16 +31,16 @@ class PaymentServiceTest {
     @Autowired
     private PaymentService paymentService;
 
+    @Autowired
+    private ReservationRepository reservationRepository;
+
     @Test
     void 결제_저장_테스트() {
         // given
         PaymentInfo paymentInfo = new PaymentInfo("key", "orderId", 1000L);
-        MemberReservationRequest request = createRequest(
-            LocalDate.of(2030, 3, 3),
-            1L, 1L, paymentInfo);
+        Reservation reservation = reservationRepository.findById(1L).get();
         PaymentRequest paymentRequest = new PaymentRequest(
-            request.date(), request.timeId(), request.themeId(), request.paymentKey(),
-            request.orderId(), request.amount()
+            reservation, paymentInfo.getPaymentKey(), paymentInfo.getOrderId(), paymentInfo.getAmount()
         );
         TossConfirmRequest tossConfirmRequest = new TossConfirmRequest(paymentRequest.paymentKey(),
             paymentRequest.orderId(), paymentRequest.amount());
@@ -53,19 +53,13 @@ class PaymentServiceTest {
             .thenReturn(tossConfirmResponse);
 
         // when
-        Payment payment = paymentService.addPayment(paymentRequest, 1L);
+        Payment payment = paymentService.addPayment(paymentRequest);
 
         // then
         assertAll(
             () -> assertThat(payment.getId()).isNotNull(),
             () -> assertThat(payment.getPaymentInfo().equals(paymentInfo))
         );
-    }
-
-    private MemberReservationRequest createRequest(LocalDate now, Long timeId, Long themeId,
-        PaymentInfo paymentInfo) {
-        return new MemberReservationRequest(now, timeId, themeId, paymentInfo.getPaymentKey(),
-            paymentInfo.getOrderId(), paymentInfo.getAmount());
     }
 }
 

--- a/src/test/java/roomescape/reservation/MemberReservationApiTest.java
+++ b/src/test/java/roomescape/reservation/MemberReservationApiTest.java
@@ -3,7 +3,6 @@ package roomescape.reservation;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,7 +60,7 @@ public class MemberReservationApiTest {
 
     @Test
     void 예약을_추가한다() {
-        when(paymentService.addPayment(any(), anyLong()))
+        when(paymentService.addPayment(any()))
             .thenReturn(mock(Payment.class));
 
         final MemberReservationRequest request = createRequest(LocalDate.now().plusDays(1), 1L, 1L);
@@ -104,7 +103,7 @@ public class MemberReservationApiTest {
 
     @Test
     void 과거날짜로_예약을_하면_에러를_반환한다() {
-        when(paymentService.addPayment(any(), anyLong()))
+        when(paymentService.addPayment(any()))
             .thenReturn(mock(Payment.class));
 
         final MemberReservationRequest request = createRequest(LocalDate.now().minusDays(10), 1L,
@@ -123,7 +122,7 @@ public class MemberReservationApiTest {
 
     @Test
     void 중복된_시간에_예약을_하면_에러가_발생한다() {
-        when(paymentService.addPayment(any(), anyLong()))
+        when(paymentService.addPayment(any()))
             .thenReturn(mock(Payment.class));
 
         final MemberReservationRequest request1 = createRequest(

--- a/src/test/java/roomescape/reservation/MemberReservationApiTest.java
+++ b/src/test/java/roomescape/reservation/MemberReservationApiTest.java
@@ -155,6 +155,6 @@ public class MemberReservationApiTest {
     }
 
     private MemberReservationRequest createRequest(LocalDate now, Long timeId, Long themeId) {
-        return new MemberReservationRequest(now, timeId, themeId, "key", "orderId", 1000L);
+        return new MemberReservationRequest(now, timeId, themeId);
     }
 }

--- a/src/test/java/roomescape/reservation/MemberReservationApiTest.java
+++ b/src/test/java/roomescape/reservation/MemberReservationApiTest.java
@@ -2,9 +2,6 @@ package roomescape.reservation;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -18,11 +15,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import roomescape.login.application.TokenCookieService;
 import roomescape.login.application.dto.LoginRequest;
-import roomescape.payment.application.PaymentService;
-import roomescape.payment.domain.Payment;
 import roomescape.reservation.application.dto.MemberReservationRequest;
 
 @ActiveProfiles("test")
@@ -33,9 +27,6 @@ public class MemberReservationApiTest {
     @LocalServerPort
     private int port;
     private String token;
-
-    @MockitoBean
-    private PaymentService paymentService;
 
     @BeforeEach
     void setUp() {
@@ -60,9 +51,6 @@ public class MemberReservationApiTest {
 
     @Test
     void 예약을_추가한다() {
-        when(paymentService.addPayment(any()))
-            .thenReturn(mock(Payment.class));
-
         final MemberReservationRequest request = createRequest(LocalDate.now().plusDays(1), 1L, 1L);
         RestAssured.given().log().all()
             .cookie(TokenCookieService.COOKIE_TOKEN_KEY, token)
@@ -103,9 +91,6 @@ public class MemberReservationApiTest {
 
     @Test
     void 과거날짜로_예약을_하면_에러를_반환한다() {
-        when(paymentService.addPayment(any()))
-            .thenReturn(mock(Payment.class));
-
         final MemberReservationRequest request = createRequest(LocalDate.now().minusDays(10), 1L,
             1L);
 
@@ -122,9 +107,6 @@ public class MemberReservationApiTest {
 
     @Test
     void 중복된_시간에_예약을_하면_에러가_발생한다() {
-        when(paymentService.addPayment(any()))
-            .thenReturn(mock(Payment.class));
-
         final MemberReservationRequest request1 = createRequest(
             LocalDate.now().plusDays(10),
             1L,

--- a/src/test/java/roomescape/reservation/application/ReservationSchedulerTest.java
+++ b/src/test/java/roomescape/reservation/application/ReservationSchedulerTest.java
@@ -26,10 +26,13 @@ public class ReservationSchedulerTest {
 
     @DisplayName("결제 대기상태에서 대기 시간을 초과하면 삭제가 되어야 한다.")
     @Test
-    void payment_pending_and_over_waiting_time_then_delete_reservation() throws InterruptedException {
+    void payment_pending_and_over_waiting_time_then_delete_reservation()
+        throws InterruptedException {
         // given
-        MemberReservationRequest memberReservationRequest = new MemberReservationRequest(LocalDate.now().plusDays(1), 1L, 1L);
-        ReservationResponse reservationResponse = reservationService.addMemberReservation(memberReservationRequest, 1L);
+        MemberReservationRequest memberReservationRequest = new MemberReservationRequest(
+            LocalDate.now().plusDays(1), 1L, 1L);
+        ReservationResponse reservationResponse = reservationService.addMemberReservation(
+            memberReservationRequest, 1L);
         assertThat(reservationRepository.findById(reservationResponse.id())).isNotEmpty();
 
         // when

--- a/src/test/java/roomescape/reservation/application/ReservationSchedulerTest.java
+++ b/src/test/java/roomescape/reservation/application/ReservationSchedulerTest.java
@@ -1,0 +1,42 @@
+package roomescape.reservation.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import roomescape.reservation.application.dto.MemberReservationRequest;
+import roomescape.reservation.application.dto.ReservationResponse;
+import roomescape.reservation.domain.repository.ReservationRepository;
+
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest
+public class ReservationSchedulerTest {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @DisplayName("결제 대기상태에서 대기 시간을 초과하면 삭제가 되어야 한다.")
+    @Test
+    void payment_pending_and_over_waiting_time_then_delete_reservation() throws InterruptedException {
+        // given
+        MemberReservationRequest memberReservationRequest = new MemberReservationRequest(LocalDate.now().plusDays(1), 1L, 1L);
+        ReservationResponse reservationResponse = reservationService.addMemberReservation(memberReservationRequest, 1L);
+        assertThat(reservationRepository.findById(reservationResponse.id())).isNotEmpty();
+
+        // when
+        Thread.sleep(2000);
+
+        // then
+        assertThat(reservationRepository.findById(reservationResponse.id())).isEmpty();
+    }
+
+}

--- a/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
@@ -152,6 +152,6 @@ class ReservationServiceTest {
     }
 
     private MemberReservationRequest createRequest(LocalDate now, Long timeId, Long themeId) {
-        return new MemberReservationRequest(now, timeId, themeId, "key", "orderId", 1000L);
+        return new MemberReservationRequest(now, timeId, themeId);
     }
 }

--- a/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
@@ -126,7 +126,8 @@ class ReservationServiceTest {
             memberReservationRequest, 1L);
 
         // 기존 member2의 예약 내역
-        List<MyReservationAndPaymentInfo> beforeMemberReservations = reservationService.findByMemberId(2L);
+        List<MyReservationAndPaymentInfo> beforeMemberReservations = reservationService.findByMemberId(
+            2L);
         assertThat(beforeMemberReservations).hasSize(2);
 
         WaitingIdResponse waitingIdResponse = waitingService.addWaiting(memberReservationRequest,

--- a/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
@@ -3,7 +3,6 @@ package roomescape.reservation.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,7 +53,7 @@ class ReservationServiceTest {
         // given
         final MemberReservationRequest request = createRequest(LocalDate.now().plusDays(1), 1L, 1L);
 
-        when(paymentService.addPayment(any(), anyLong()))
+        when(paymentService.addPayment(any()))
             .thenReturn(mock(Payment.class));
 
         // when & then

--- a/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
@@ -16,6 +16,7 @@ import roomescape.member.application.dto.MemberResponse;
 import roomescape.reservation.application.dto.AvailableReservationTimeResponse;
 import roomescape.reservation.application.dto.MemberReservationRequest;
 import roomescape.reservation.application.dto.MyReservation;
+import roomescape.reservation.application.dto.MyReservationAndPaymentInfo;
 import roomescape.reservation.application.dto.ReservationResponse;
 import roomescape.reservation.application.dto.ReservationTimeResponse;
 import roomescape.theme.application.dto.ThemeResponse;
@@ -108,7 +109,7 @@ class ReservationServiceTest {
         final long memberId = 1L;
 
         // when
-        final List<MyReservation> responses = reservationService.findByMemberId(memberId);
+        List<MyReservationAndPaymentInfo> responses = reservationService.findByMemberId(memberId);
 
         // then
         assertThat(responses).hasSize(2);
@@ -125,7 +126,7 @@ class ReservationServiceTest {
             memberReservationRequest, 1L);
 
         // 기존 member2의 예약 내역
-        List<MyReservation> beforeMemberReservations = reservationService.findByMemberId(2L);
+        List<MyReservationAndPaymentInfo> beforeMemberReservations = reservationService.findByMemberId(2L);
         assertThat(beforeMemberReservations).hasSize(2);
 
         WaitingIdResponse waitingIdResponse = waitingService.addWaiting(memberReservationRequest,
@@ -135,7 +136,7 @@ class ReservationServiceTest {
         reservationService.deleteReservationAndGetFirstWaiting(reservationResponse.id());
 
         //then
-        List<MyReservation> reservations = reservationService.findByMemberId(1L);
+        List<MyReservationAndPaymentInfo> reservations = reservationService.findByMemberId(1L);
         boolean hasReservation = reservations.stream()
             .anyMatch(reservation -> reservation.id().equals(reservationResponse.id()));
 
@@ -143,7 +144,7 @@ class ReservationServiceTest {
         boolean hasWaiting = waitingsFromMember.stream()
             .anyMatch(waiting -> waiting.id().equals(waitingIdResponse.waitingId()));
 
-        List<MyReservation> findReservations = reservationService.findByMemberId(2L);
+        List<MyReservationAndPaymentInfo> findReservations = reservationService.findByMemberId(2L);
 
         //then
         assertThat(hasReservation).isFalse();

--- a/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
@@ -2,9 +2,6 @@ package roomescape.reservation.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -15,10 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import roomescape.member.application.dto.MemberResponse;
-import roomescape.payment.application.PaymentService;
-import roomescape.payment.domain.Payment;
 import roomescape.reservation.application.dto.AvailableReservationTimeResponse;
 import roomescape.reservation.application.dto.MemberReservationRequest;
 import roomescape.reservation.application.dto.MyReservation;
@@ -36,9 +30,6 @@ class ReservationServiceTest {
     @Autowired
     private ReservationService reservationService;
 
-    @MockitoBean
-    private PaymentService paymentService;
-
     @Autowired
     private WaitingService waitingService;
 
@@ -52,10 +43,6 @@ class ReservationServiceTest {
     void 예약을_추가한다() {
         // given
         final MemberReservationRequest request = createRequest(LocalDate.now().plusDays(1), 1L, 1L);
-
-        when(paymentService.addPayment(any()))
-            .thenReturn(mock(Payment.class));
-
         // when & then
         assertThat(reservationService.addMemberReservation(request, 1L)).isEqualTo(
             new ReservationResponse(

--- a/src/test/java/roomescape/reservation/domain/ReservationTest.java
+++ b/src/test/java/roomescape/reservation/domain/ReservationTest.java
@@ -2,6 +2,7 @@ package roomescape.reservation.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static roomescape.reservation.domain.ReservationStatus.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -23,7 +24,7 @@ class ReservationTest {
 
         final Theme theme = new Theme(1L, "인터스텔라", "설명1", "썸네일1");
         final Reservation reservation = new Reservation(1L, LocalDate.of(2025, 1, 1), ten, theme,
-            new Member("엠제이", "", "", Role.MEMBER));
+            new Member("엠제이", "", "", Role.MEMBER), PENDING);
 
         // 현재 테마 이용시간은 2시간으로 고정됨
         // 10시로 예약을 했으니, 8시 초과 12시 미만일 때는 예약을 할 수 없음

--- a/src/test/java/roomescape/reservation/domain/ReservationTest.java
+++ b/src/test/java/roomescape/reservation/domain/ReservationTest.java
@@ -2,7 +2,7 @@ package roomescape.reservation.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static roomescape.reservation.domain.ReservationStatus.*;
+import static roomescape.reservation.domain.PaymentStatus.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/test/java/roomescape/reservation/domain/ReservationTest.java
+++ b/src/test/java/roomescape/reservation/domain/ReservationTest.java
@@ -2,7 +2,7 @@ package roomescape.reservation.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static roomescape.reservation.domain.PaymentStatus.*;
+import static roomescape.reservation.domain.PaymentStatus.PENDING;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/test/java/roomescape/waiting/WaitingApiTest.java
+++ b/src/test/java/roomescape/waiting/WaitingApiTest.java
@@ -189,6 +189,6 @@ public class WaitingApiTest {
     }
 
     private MemberReservationRequest createRequest(LocalDate now, Long timeId, Long themeId) {
-        return new MemberReservationRequest(now, timeId, themeId, "key", "orderId", 1000L);
+        return new MemberReservationRequest(now, timeId, themeId);
     }
 }

--- a/src/test/java/roomescape/waiting/WaitingServiceTest.java
+++ b/src/test/java/roomescape/waiting/WaitingServiceTest.java
@@ -109,7 +109,7 @@ public class WaitingServiceTest {
     }
 
     private MemberReservationRequest createRequest(LocalDate now, Long timeId, Long themeId) {
-        return new MemberReservationRequest(now, timeId, themeId, "key", "orderId", 1000L);
+        return new MemberReservationRequest(now, timeId, themeId);
     }
 
 }

--- a/src/test/java/roomescape/waiting/WaitingServiceTest.java
+++ b/src/test/java/roomescape/waiting/WaitingServiceTest.java
@@ -3,7 +3,6 @@ package roomescape.waiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,7 +56,7 @@ public class WaitingServiceTest {
             1L, 1L
         );
 
-        when(paymentService.addPayment(any(), anyLong()))
+        when(paymentService.addPayment(any()))
             .thenReturn(mock(Payment.class));
         reservationService.addMemberReservation(memberReservationRequest, 1L);
 

--- a/src/test/java/roomescape/waiting/WaitingServiceTest.java
+++ b/src/test/java/roomescape/waiting/WaitingServiceTest.java
@@ -2,9 +2,6 @@ package roomescape.waiting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -12,10 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
-import roomescape.payment.application.PaymentService;
-import roomescape.payment.domain.Payment;
 import roomescape.reservation.application.ReservationService;
 import roomescape.reservation.application.dto.MemberReservationRequest;
 import roomescape.waiting.application.WaitingService;
@@ -28,9 +22,6 @@ public class WaitingServiceTest {
 
     @Autowired
     private WaitingService waitingService;
-
-    @MockitoBean
-    private PaymentService paymentService;
 
     @Autowired
     private ReservationService reservationService;
@@ -55,9 +46,6 @@ public class WaitingServiceTest {
             LocalDate.of(2026, 5, 10),
             1L, 1L
         );
-
-        when(paymentService.addPayment(any()))
-            .thenReturn(mock(Payment.class));
         reservationService.addMemberReservation(memberReservationRequest, 1L);
 
         //when, then

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -24,3 +24,9 @@ security:
       secret-key: s8R$kQz3nZ!L5pT7c@J#xM9vB1&uD6hE
       access:
         expire-length: 600000 # 10 분
+
+scheduler:
+  request:
+    time: 600 # 1분
+  valid:
+    period: 1s

--- a/src/test/resources/test.sql
+++ b/src/test/resources/test.sql
@@ -32,17 +32,17 @@ VALUES ('컨저링', '실화 기반의 공포가 현실이 된다, 악령이 도
 
 -- 2 -> 1 -> 3
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 1, 2, 1, 'SUCCESS');
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -4, CURRENT_DATE), 2, 2, 1, 'SUCCESS');
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 2, 2, 2, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 3, 1, 2, 'SUCCESS');
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 1, 3, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+INSERT INTO reservation (date, time_id, theme_id, member_id, payment_status)
 VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 3, 3, 'SUCCESS');

--- a/src/test/resources/test.sql
+++ b/src/test/resources/test.sql
@@ -32,17 +32,17 @@ VALUES ('컨저링', '실화 기반의 공포가 현실이 된다, 악령이 도
 
 -- 2 -> 1 -> 3
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 1, 2, 1);
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -4, CURRENT_DATE), 2, 2, 1);
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 2, 2, 2);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 1, 2, 1, 'SUCCESS');
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -4, CURRENT_DATE), 2, 2, 1, 'SUCCESS');
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 2, 2, 2, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 3, 1, 2);
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 1, 3);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 3, 1, 2, 'SUCCESS');
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 1, 3, 'SUCCESS');
 
-INSERT INTO reservation (date, time_id, theme_id, member_id)
-VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 3, 3);
+INSERT INTO reservation (date, time_id, theme_id, member_id, reservation_status)
+VALUES (DATEADD('DAY', -3, CURRENT_DATE), 4, 3, 3, 'SUCCESS');


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?
- [x] [프롤로그](https://prolog.techcourse.co.kr)에 셀프 체크를 작성했나요?
  <!-- 작성한 셀프 체크의 링크를 남겨주세요. -->

https://prolog.techcourse.co.kr/studylogs/4451

## 객체지향 생활체조 요구사항을 얼마나 잘 충족했다고 생각하시나요?
### 1~5점 중에서 선택해주세요.

- [ ] 1 (전혀 충족하지 못함)
- [ ] 2
- [x] 3 (보통)
- [ ] 4
- [ ] 5 (완벽하게 충족)

### 선택한 점수의 이유를 적어주세요.
<!-- 이유 작성 -->
원칙을 지킨 것도 있고, 못 지킨 부분도 있습니다만, 최대한 지키려고 노력했습니다. 하지만 완벽하지는 않네요.

## 베이스 코드 선택 체크
- [x] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

미션과 관련된 주요 파일들은 하단의 md파일에 추가해뒀습니다. 
[REVIEWER.md](https://github.com/woowacourse/spring-roomescape-payment/pull/257/files#diff-41ea3b9813ed4c8cf2416bea23539812513edacff13fcb6582f185f8fc1bbe6c)
- 이슈 : 배포가 제대로 되지 않는 문제가 확인되었는데, 보안 그룹 및 방화벽 문제같아 월요일에 캠퍼스 가서 확인해보겠습니다.

안녕하세요 범블비! 클라이언트 로직이 마음에 안 들어 수정하다보니 시간이 꽤 걸렸습니다.
코드에 대해 오래 고민한 만큼 다양한 고민거리를 찾을 수 있었고, 이에 대해 범블비의 의견이 궁금해 하단에 적어두겠습니다!
 
1. Schedule의 사용
예약(결제 상태 pending) -> 결제(결제 상태 success) 의 흐름을 가져가고 있습니다.
특이한 점은 주어진 코드를 따라 결제와 예약을 하나의 단위로 보는게 아니라, 별개의 요청으로 분리했습니다.
위의 흐름대로 설계를 하니, 결제를 하지 않은 유저가 예악을 계속 가지고 있다는 문제점이 있었고, 이를 해결하기 위해 schedule을 도입해 1분마다 쿼리문(15분이 지나도, 결제상태가 pending인 예약을 찾아 삭제해라)을 날립니다. 
1분마다 쿼리문을 계속 날리고 있는데, 문제점은 없을까요? 
위의 비즈니스 흐름에 대해 어떻게 생각하는지 궁금합니다! 또한, schedule 보다 더 좋은 방법이 있는지도 궁금합니다.


2. Api 노출의 위험성
Swagger는 기본적으로 swagger-ui/index.html의 경로를 제공해줍니다. Swagger는 API의 명세에 대해 잘 정리가 되어 있는 곳이기에, 이 uri가 노출되면 보안 문제의 시발점이 될 것 같다고 판단했습니다. 그래서 경로를 변경하고 싶었지만 실패했습니다. (계속 시도해볼 예정)
범블비는 개발 환경에서 사용되는 API 노출에 대해 어떻게 생각하시나요? API 명세는 외부에 유출이 되면 안 되는걸까요?


3. 사용자 추적 로그
01c511bee82fc1769a68e59aaf6c57aa38b1902d
사용자 추적 로그를 남기면, 운영 환경에서 편리할 것 같다 생각했습니다.
예를 들면, A유저가 OO일 OO시 OO분에 예약 요청을 보냈는데, 예약이 안 되었다는 문의가 들어올 경우, 로그를 통해 제대로 요청이 왔는지 확인할 수 있다고 생각했습니다. 로그를 남기지 않는다면, 확인조차 못 한다고 생각해요. 하지만 위의 커밋처럼 모든 성공 케이스에 로그를 남기자니, 비즈니스 로직이 더러워진다는 느낌을 받았습니다. 성공 케이스에 대한 로그는 필요할까요? 운영 환경에서 사용하는 로그 사용법이 따로 있는지 궁금합니다! 

4. Reservation - Payment의 관계
Payment는 Reservation이 없다면 존재할 수 없습니다. 
그렇기에 Payment - Reservation 에서 연관관계의 주인을 외래키를 들고있는 Payment로 설정했습니다.
하지만 이번 2단계에서, 예약을 조회할 때 결제 내역을 포함해 가져오라는 요구사항이 추가되었습니다.
기존 코드 :
```
List<Reservation> reservations = reservationRepository.findByMemberId(memberId); 
```

위의 코드의 문제점은 Payment - Reservation의 관계에서 단방향 연관관계의 주인이 Payment이기에 Reservation은 Payment의 존재를 모르고 있습니다. 즉, reservation.getPayment() 라는 메서드 자체가 불가능한 것이죠.
이 문제를 해결하기 위해서는 payment.getReservation() 으로 메서드를 호출해야 하는데, 메서드가 매우 부자연스럽다고 판단했습니다.
(예약 정보를 가져오는 메서드가 reservation.() 가 아닌, payment.()로 호출되어 매우 어색하다고 느꼈음)
이 문제를 해결하기 위해 Payment - Reservation이 양방향으로 관계를 가지고 있게 설정했습니다. 
이 과정에서, reservation.getPayment() 와 같은 메서드를 호출할 수는 있지만, null값을 가져올 확률이 상당히 높은 코드가 되었습니다.
연관관계의 주인을 바꿔도 여전히 null 값이 존재합니다.
범블비는 이에 대해 어떻게 생각하나요? null 값을 직접적으로 다뤄도 된다고 생각하시나요? 
혹은 더 좋은 방법이 있을까요?


아직 수정해야 할 부분이 많지만, 상단의 질문에 대해 범블비의 의견이 궁금해 빠르게 리뷰 보내봅니다!


### 📌 코드리뷰 질문 그라운드룰 (지우지 마세요)
✅ 많은 사람과 공유하고 토론해보는 것이 더 좋은 질문에는, 리뷰어가 💬말풍선 이모지를 남겨 토론을 추천할 수 있어요.  
✅ 토론을 추천받은 질문은 `#be-7기-잡담-질답`슬랙채널이나 캠퍼스에서 자유롭게 토론을 이어가보세요!  
✅ 코드에 대한 맥락 없이 리뷰어의 주관적인 의견을 묻거나, 단순히 현업에서는 어떻게 하는지를 묻는 질문은 코드 리뷰 본문에는 어울리지 않아요.  
코드 리뷰는 변경된 코드의 목적, 의도, 품질을 중심으로 논의하는 자리예요.  
✅ 코드와 관련된 질문이 있다면 PR 본문에 적기보다는, 해당 코드를 선택해 코멘트를 남겨주세요.
